### PR TITLE
#7: Phase 2 — Design and implementation skills

### DIFF
--- a/skills/architecture/architecture-consult/SKILL.md
+++ b/skills/architecture/architecture-consult/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: architecture-consult
+description: Consults current architecture docs, ADRs, and codebase to identify relevant components, modules, and files. Use before adding a feature, scoping a change, or placing new code; surfaces constraints and existing decisions.
+---
+
+# Architecture Consult
+
+Reads project architecture documentation and codebase to answer: *where does this change belong, and what constraints apply?*
+
+## When to use
+
+- Before starting implementation of a new feature or fix
+- When scope of a change is unclear (which modules, which layers)
+- When an ADR or prior decision may constrain the approach
+
+## Instructions
+
+1. **Locate architecture docs** — check `docs/architecture/` for arc42 sections (01–12) and `docs/architecture/adr/` for ADRs.
+2. **Read CLAUDE.md** — project-level CLAUDE.md contains module boundaries, key patterns, and critical rules.
+3. **Identify relevant building blocks** — use codebase search (`rg`, `gh`, file tree) to find existing modules, classes, or services that touch the feature area.
+4. **Check ADRs** — scan ADR index (`09-decisions.md` or `adr/`) for decisions that constrain the approach (e.g. "use async-first", "SQLAlchemy 2.0 style").
+5. **Map placement** — state which module/package/file the change belongs in, and which layer (route → service → repository → provider).
+6. **Surface constraints** — list any ADRs, patterns, or rules that apply (toolchain, naming, style, testing).
+
+## Output format
+
+```markdown
+## Architecture Consult: [Feature/Change]
+
+### Relevant components
+- `module/path/` — [role]
+- `module/path/file.py` — [what it does]
+
+### Applicable ADRs / decisions
+- ADR-NNN: [title] — [constraint it imposes]
+
+### Placement recommendation
+[One paragraph: where to add code, which layer, which files to create/modify]
+
+### Constraints
+- [Rule or pattern that applies]
+```
+
+## Integration
+
+- Read `docs/architecture/` sections relevant to the domain (§5 building blocks, §8 crosscutting, §9 decisions).
+- Use `rg <term> --type py` or `gh` to locate existing implementations.
+- Compose with [design-consult](../../design/design-consult/SKILL.md) for detailed placement.

--- a/skills/design/design-consult/SKILL.md
+++ b/skills/design/design-consult/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: design-consult
+description: Consults current design and architecture to place new code correctly within existing components, interfaces, and data flows. Use after architecture-consult, before implementation-construction; ensures single responsibility and correct layering.
+---
+
+# Design Consult
+
+Maps where new code fits within existing components, interfaces, and data flows. Focuses on *detailed* placement — files, classes, method signatures — rather than high-level modules.
+
+## When to use
+
+- After [architecture-consult](../../architecture/architecture-consult/SKILL.md) has identified the relevant module
+- Before writing new classes or functions
+- When you need to decide between extending an existing class vs. creating a new one
+
+## Instructions
+
+1. **Read existing component** — open the relevant file(s) identified by architecture-consult; scan class/function signatures and docstrings.
+2. **Check interfaces and abstractions** — look for base classes, Protocols, or ABCs the new code must implement or follow.
+3. **Identify extension points** — factory functions, registries, or plugin patterns where the new code should register.
+4. **Check naming conventions** — match existing patterns (module names, class names, method names, file layout).
+5. **Decide: extend vs. create** — prefer extending existing abstractions; create a new file only when single responsibility demands it.
+6. **Define method signatures** — draft public API (function names, parameter types, return types) before writing the body.
+
+## Output format
+
+```markdown
+## Design Consult: [Feature/Component]
+
+### Existing components consulted
+- `path/to/file.py` — `ClassName` — [what it does]
+
+### Interfaces / abstractions to implement
+- `BaseX` in `path/to/base.py` — methods: `method_a(...)`, `method_b(...)`
+
+### Extension point
+- Register in `factory.py::create_x()` by adding a branch for `"new-type"`
+
+### New file / class design
+**File:** `module/path/new_thing.py`
+**Class:** `NewThing(BaseX)`
+**Public methods:**
+- `method_a(param: Type) -> ReturnType`
+
+### Naming conventions applied
+- [Convention from existing code]
+```
+
+## Integration
+
+- Follows [architecture-consult](../../architecture/architecture-consult/SKILL.md).
+- Feeds into [implementation-construction](../../implementation/implementation-construction/SKILL.md).

--- a/skills/implementation/implementation-construction/SKILL.md
+++ b/skills/implementation/implementation-construction/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: implementation-construction
+description: Writes new code following Code Complete 2 construction principles: consistent naming, single responsibility, type hints, docstrings, and minimal surface area. Use when implementing a designed component or function; follows design-consult output.
+---
+
+# Implementation Construction
+
+Constructs code from a design specification following Code Complete 2 principles. Focuses on correctness, clarity, and consistency — not cleverness.
+
+## When to use
+
+- After [design-consult](../../design/design-consult/SKILL.md) has defined files, classes, and method signatures
+- When writing new classes, functions, or modules
+- When refactoring existing code to meet construction standards
+
+## Principles (Code Complete 2)
+
+| Principle | Application |
+|-----------|-------------|
+| **One purpose** | Each function/class does one thing; name reflects it |
+| **Minimal surface** | Private by default; expose only what callers need |
+| **Intention-revealing names** | Names describe *what*, not *how* |
+| **Type hints on all public signatures** | Enables tooling and documents intent |
+| **Defensive at boundaries** | Validate at system entry points (API, user input); trust internal code |
+| **Short functions** | Target ≤ 20 lines; extract helpers when logic nests 3+ levels |
+| **No premature abstraction** | Abstract when you have 3+ concrete cases; not before |
+
+## Instructions
+
+1. **Start from design-consult output** — use the file, class, and method signatures as the skeleton.
+2. **Write the signature first** — include type hints and a one-line docstring before the body.
+3. **Implement body** — keep it short; extract logic into private helpers if needed.
+4. **Match project style** — follow the repo's `pyproject.toml` line length, import style (absolute), and naming conventions.
+5. **No TODO stubs without tracking** — if something is deferred, open an issue; do not leave `TODO: implement this`.
+6. **Check project toolchain** — run `uv run ruff check .` and `uv run ruff format --check .` before committing.
+
+## Checklist
+
+- [ ] Type hints on all public function signatures
+- [ ] Docstring on every public class and function (one line minimum)
+- [ ] No `import *`; absolute imports only
+- [ ] No mutable default arguments (`def f(x=[])`)
+- [ ] Constants at module level, not buried in functions
+- [ ] New code follows existing naming conventions in the file
+
+## Output format
+
+Produce the implementation as a code block with the target file path:
+
+```python
+# path/to/module/new_thing.py
+
+from module.base import BaseX
+
+
+class NewThing(BaseX):
+    """One-line description of what this does."""
+
+    def method_a(self, param: str) -> int:
+        """Returns the length of param after processing."""
+        ...
+```
+
+## Integration
+
+- Follows [design-consult](../../design/design-consult/SKILL.md).
+- Before committing, run [quality-gate](../../quality-gate/SKILL.md).
+- After implementation, trigger [validation-draft](../../validation/validation-draft/SKILL.md) if not already done.

--- a/skills/quality-gate/SKILL.md
+++ b/skills/quality-gate/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: quality-gate
+description: Runs lint, format, type check, and security scan; enforces pre-commit hooks. Use before every commit and as the final step before opening a PR. Invokes sub-skills (lint, format, type, security) as needed.
+---
+
+# Quality Gate
+
+Enforces code quality before commits and PRs. Runs the minimum required checks for the repo's toolchain.
+
+## When to use
+
+- Before every `git commit`
+- Before opening a PR
+- After implementation to catch style and correctness issues early
+
+## Standard checks
+
+Run these in order (fail fast):
+
+```bash
+# 1. Lint — catch style and logic issues
+uv run ruff check .
+
+# 2. Format — enforce consistent style
+uv run ruff format --check .
+
+# 3. Type check (if configured)
+uv run pyright   # or: uv run mypy
+
+# 4. Tests
+uv run pytest
+
+# 5. Pre-commit (runs all hooks)
+pre-commit run --all-files
+```
+
+## Per-check sub-skills
+
+| Sub-skill | Tool | When |
+|-----------|------|------|
+| [quality-gate-lint](quality-gate-lint/SKILL.md) | ruff check | Every commit |
+| [quality-gate-format](quality-gate-format/SKILL.md) | ruff format | Every commit |
+| [quality-gate-type](quality-gate-type/SKILL.md) | pyright / mypy | Before PR |
+| [quality-gate-security](quality-gate-security/SKILL.md) | bandit / npm audit | Before PR / CI |
+
+## Fix before commit — not after
+
+- Fix lint and format errors immediately; do not `--no-verify`.
+- If a pre-commit hook blocks a commit, investigate the root cause — do not bypass.
+- If a check is not configured for this repo, skip it and note the gap.
+
+## Repo-specific toolchain
+
+Check the repo's `pyproject.toml` for:
+- `[tool.ruff]` — line length, selected rules
+- `[tool.pyright]` or `[tool.mypy]` — type checking configuration
+- `.pre-commit-config.yaml` — active hooks
+
+## Output
+
+Report pass/fail per check:
+
+```markdown
+## Quality Gate Results
+
+- [x] ruff check — clean
+- [x] ruff format --check — clean
+- [ ] pyright — 2 errors (see below)
+- [x] pytest — 42 passed, 0 failed
+```
+
+List errors with file and line reference for any failures.
+
+## Integration
+
+- Run after [implementation-construction](../implementation/implementation-construction/SKILL.md).
+- Must pass before [integration-commit](../integration/integration-commit/SKILL.md).

--- a/skills/validation/validation-draft/SKILL.md
+++ b/skills/validation/validation-draft/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: validation-draft
+description: Drafts validation steps, BDD scenarios, or test cases from issue acceptance criteria. Use before or during implementation to produce an executable checklist; supports TDD (run before coding) and post-implementation verification.
+---
+
+# Validation Draft
+
+Transforms acceptance criteria into an executable validation checklist. Produces concrete steps that any engineer can run without interpretation.
+
+## When to use
+
+- Before implementation (TDD): draft tests and verification steps from acceptance criteria
+- During implementation: know exactly what "done" looks like before writing code
+- After implementation: verify all criteria are met before opening a PR
+
+## Instructions
+
+1. **Read acceptance criteria** — each `- [ ]` checkbox in the issue is a criterion to validate.
+2. **For each criterion**, produce:
+   - The **command or action** to execute (exact CLI command, URL + click path, or test invocation)
+   - The **expected result** (exit code, output text, UI state, response body)
+3. **Identify test type** — unit test, integration test, manual UI flow, or CLI smoke test.
+4. **Order by dependency** — infrastructure first (app starts), then feature tests, then edge cases.
+5. **Flag untestable criteria** — if a criterion cannot be validated automatically, flag it for manual review.
+
+## Validation step format
+
+```markdown
+### [Criterion summary]
+**Type:** unit | integration | manual | smoke
+**Command / action:**
+```bash
+<exact command>
+```
+**Expected result:** [What to observe — exit code, output, UI state]
+```
+
+## BDD scenario format (optional)
+
+For feature-level criteria, use Gherkin when it aids clarity:
+
+```gherkin
+Given [precondition]
+When  [action]
+Then  [expected outcome]
+```
+
+## Example
+
+**Criterion:** "`uv run pytest -v --cov=. --cov-fail-under=80` exits 0; new modules covered"
+
+```markdown
+### Tests pass with ≥80% coverage
+**Type:** integration
+**Command:**
+```bash
+cd backend && uv run pytest -v --cov=. --cov-fail-under=80
+```
+**Expected result:** Exit 0; coverage report shows ≥80% for new modules.
+```
+
+## Output format
+
+Produce a `## Validation Checklist` section suitable for pasting into the issue or a `tmp/validation.md` scratch file:
+
+```markdown
+## Validation Checklist
+
+- [ ] [Criterion 1] — `<command>` → [expected result]
+- [ ] [Criterion 2] — Open [URL], click [path] → [expected state]
+- [ ] [Criterion 3] — `<test command>` exits 0
+```
+
+## Integration
+
+- Input: acceptance criteria from [issue-acceptance-criteria](../../issue-workflow/issue-acceptance-criteria/SKILL.md).
+- Output feeds: [test-write](../../test/test-write/SKILL.md) and [validation-run](../validation-run/SKILL.md).
+- In TDD flow: run *before* [implementation-construction](../../implementation/implementation-construction/SKILL.md).


### PR DESCRIPTION
Closes #7

## Summary
- `skills/architecture/architecture-consult/SKILL.md` — consults arc42 docs, ADRs, and codebase to identify placement and constraints before implementation
- `skills/design/design-consult/SKILL.md` — maps new code to existing files, interfaces, and extension points; defines method signatures before writing bodies
- `skills/implementation/implementation-construction/SKILL.md` — Code Complete 2 construction principles: naming, type hints, single responsibility, minimal surface
- `skills/validation/validation-draft/SKILL.md` — transforms acceptance criteria into executable checklist (BDD/TDD); supports pre-implementation and post-implementation verification
- `skills/quality-gate/SKILL.md` — orchestrates lint/format/type/security/test checks; references sub-skills; fail-fast order

## Cross-references
Skills reference each other in the correct lifecycle order:
`architecture-consult` → `design-consult` → `implementation-construction` → `quality-gate`
`issue-acceptance-criteria` → `validation-draft` → `implementation-construction`

## Test plan
- [x] Trigger `architecture-consult` on `on_prem_rag`; verify it surfaces relevant modules and ADRs
- [x] Trigger `implementation-construction` for a simple function; verify type hints and docstring in output
- [x] Trigger `validation-draft` on an issue with acceptance criteria; verify each criterion has a copy-pastable command
- [x] Trigger `quality-gate`; verify it emits the standard ruff/pytest commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)