### PR TITLE
chore: prefer ruff/ty in quality-gate, gitignore .serena

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ Gemfile.lock
 # Scratch files (planning, drafts) — never commit
 tmp/
 
+# Serena (MCP/IDE agent) — tool-dependent cache and config
+.serena/
+
 # IDE config dirs (.claude, .cursor) — do not commit
 # Why ignored: These dirs typically contain symlinks to skills/ (see skills/README.md).
 # Symlink targets can be machine-specific (absolute paths) or break on Windows without

--- a/skills/quality-gate/SKILL.md
+++ b/skills/quality-gate/SKILL.md
@@ -25,7 +25,7 @@ uv run ruff check .
 uv run ruff format --check .
 
 # 3. Type check (if configured)
-uv run pyright   # or: uv run mypy
+uv run ty        # Astral type checker; or: uv run pyright
 
 # 4. Tests
 uv run pytest
@@ -42,8 +42,8 @@ When these sub-skills are created, invoke them for per-check focus. Until then, 
 |-----------|------|------|
 | quality-gate-lint | ruff check | Every commit |
 | quality-gate-format | ruff format | Every commit |
-| quality-gate-type | pyright / mypy | Before PR |
-| quality-gate-security | bandit / npm audit | Before PR / CI |
+| quality-gate-type | ty / pyright | Before PR |
+| quality-gate-security | ruff check (S rules) / bandit / npm audit | Before PR / CI |
 
 ## Fix before commit — not after
 
@@ -55,7 +55,7 @@ When these sub-skills are created, invoke them for per-check focus. Until then, 
 
 Check the repo's `pyproject.toml` for:
 - `[tool.ruff]` — line length, selected rules
-- `[tool.pyright]` or `[tool.mypy]` — type checking configuration
+- `[tool.ty]` or `[tool.pyright]` — type checking configuration
 - `.pre-commit-config.yaml` — active hooks
 
 ## Output
@@ -67,7 +67,7 @@ Report pass/fail per check:
 
 - [x] ruff check — clean
 - [x] ruff format --check — clean
-- [ ] pyright — 2 errors (see below)
+- [ ] ty — 2 errors (see below)
 - [x] pytest — 42 passed, 0 failed
 ```
 


### PR DESCRIPTION
## Changes
- **quality-gate**: Prefer Ruff ecosystem — ty replaces mypy for type checking; ruff check (S rules) for security
- **.gitignore**: Add .serena/ (Serena MCP/IDE agent cache/config — tool-dependent)

Made with [Cursor](https://cursor.com)