### PR TITLE
#33: CI: Shared base images (ci-base-images)

### DIFF
--- a/.github/workflows/build-ci-base-images.yml
+++ b/.github/workflows/build-ci-base-images.yml
@@ -1,0 +1,68 @@
+# Build CI base images and push to ghcr.io/pkuppens/pkuppens/
+# Images: ci-base-3.12, ci-hf-base-3.12, ci-whisper-3.12
+# All assets in ci-base-images/ directory.
+# Prerequisite: ghcr.io access (GITHUB_TOKEN has packages: write).
+name: Build CI Base Images
+
+on:
+  schedule:
+    # First day of each month at 00:00 UTC
+    - cron: "0 0 1 * *"
+  workflow_dispatch: {}
+
+concurrency:
+  group: build-ci-base-images
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ci-base-3.12
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ci-base-images/Dockerfile.ci-base-3.12
+          push: true
+          tags: ghcr.io/pkuppens/pkuppens/ci-base-3.12:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push ci-hf-base-3.12
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ci-base-images/Dockerfile.ci-hf-base-3.12
+          push: true
+          tags: ghcr.io/pkuppens/pkuppens/ci-hf-base-3.12:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push ci-whisper-3.12
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ci-base-images/Dockerfile.ci-whisper-3.12
+          push: true
+          tags: ghcr.io/pkuppens/pkuppens/ci-whisper-3.12:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/ci-base-images/Dockerfile.ci-base-3.12
+++ b/ci-base-images/Dockerfile.ci-base-3.12
@@ -1,0 +1,21 @@
+# ci-base-3.12: minimal CI base with Python 3.12, uv, and lint/security tooling.
+# Used as base for ci-hf-base-3.12 and ci-whisper-3.12 (sibling branches).
+# See docs/ci-base-images.md for usage and version matrix.
+FROM python:3.12-slim
+
+WORKDIR /workspace
+
+# Install uv
+RUN pip install --no-cache-dir uv
+
+# Install minimal CI tooling: pytest, ruff, bandit, safety, pytest-cov
+RUN uv pip install --system \
+    pytest>=7.4.0 \
+    pytest-cov>=4.0.0 \
+    ruff>=0.11.0 \
+    bandit>=1.7.0 \
+    safety>=2.0.0
+
+# Default working directory for jobs that use this image
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1

--- a/ci-base-images/Dockerfile.ci-hf-base-3.12
+++ b/ci-base-images/Dockerfile.ci-hf-base-3.12
@@ -1,0 +1,21 @@
+# ci-hf-base-3.12: ci-base-3.12 + HuggingFace env + embedding models.
+# For RAG, embedding tests (e.g. on_prem_rag).
+# Sibling to ci-whisper-3.12; tokenization for text differs from STT.
+FROM ghcr.io/pkuppens/pkuppens/ci-base-3.12:latest
+
+WORKDIR /workspace
+
+ENV HF_HOME=/opt/hf_cache
+ENV TRANSFORMERS_CACHE=/opt/hf_cache/hub
+ENV SENTENCE_TRANSFORMERS_HOME=/opt/hf_cache/sentence_transformers
+ENV HF_HUB_DISABLE_PROGRESS_BARS=1
+
+# Install HuggingFace deps (sentence-transformers pulls torch, transformers)
+RUN uv pip install --system \
+    sentence-transformers>=2.2.0 \
+    transformers>=4.37.0 \
+    torch>=2.2.0
+
+# Pre-download CI models (matching setup_embedding_models.py --ci)
+COPY ci-base-images/download_hf_ci_models.py /tmp/download_hf_ci_models.py
+RUN python /tmp/download_hf_ci_models.py && rm /tmp/download_hf_ci_models.py

--- a/ci-base-images/Dockerfile.ci-whisper-3.12
+++ b/ci-base-images/Dockerfile.ci-whisper-3.12
@@ -1,0 +1,12 @@
+# ci-whisper-3.12: ci-base-3.12 + faster-whisper + Whisper models.
+# For STT/voice pipelines. Sibling to ci-hf-base-3.12 (tokenization differs).
+# TTS: often client-side; document if included in your pipeline.
+FROM ghcr.io/pkuppens/pkuppens/ci-base-3.12:latest
+
+WORKDIR /workspace
+
+RUN uv pip install --system faster-whisper>=1.2.0
+
+# Pre-download Whisper base model (small enough for CI)
+COPY ci-base-images/download_whisper_model.py /tmp/download_whisper_model.py
+RUN python /tmp/download_whisper_model.py && rm /tmp/download_whisper_model.py

--- a/ci-base-images/README.md
+++ b/ci-base-images/README.md
@@ -1,0 +1,91 @@
+# CI Base Images
+
+Shared Docker base images for faster CI across pkuppens projects. Pushed to `ghcr.io/pkuppens/pkuppens/`.
+
+## Images
+
+| Image | Base | Contents | Typical Use |
+|-------|------|----------|-------------|
+| **ci-base-3.12** | python:3.12-slim | uv, pytest, ruff, bandit, safety, pytest-cov | Lint, security, minimal tests |
+| **ci-hf-base-3.12** | ci-base-3.12 | + HuggingFace env + all-MiniLM-L6-v2, bge-small-en-v1.5 | RAG, embedding tests |
+| **ci-whisper-3.12** | ci-base-3.12 | + faster-whisper + Whisper base model | STT/voice pipelines |
+
+ci-hf-base and ci-whisper are **siblings** (both FROM ci-base-3.12). Text tokenization differs from speech-to-text; stacking Whisper on HF would mix concerns.
+
+## Benefits
+
+- **Speed**: No model download per run; HF models and base tooling are baked in
+- **Consistency**: Same Python/uv/tool versions across projects
+- **Reduced runner load**: Less disk I/O and network per job
+
+## Considerations
+
+- **Image size**: ci-hf-base ~2GB; ci-whisper ~1.5GB
+- **Rebuild cadence**: Monthly (schedule) or manual (workflow_dispatch)
+- **ghcr.io access**: Requires `packages: write` for the build workflow. Validate with a manual run of Build CI Base Images.
+- **github.io**: Considered separately for deployments; document if/when used.
+
+## Version Matrix
+
+| Component | Version |
+|-----------|---------|
+| Python | 3.12 |
+| uv | latest (pip) |
+| pytest | >=7.4 |
+| ruff | >=0.11 |
+| bandit | >=1.7 |
+| safety | >=2.0 |
+| sentence-transformers | >=2.2 |
+| faster-whisper | >=1.2 |
+
+## Usage
+
+In a consuming project (e.g. on_prem_rag):
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pkuppens/pkuppens/ci-hf-base-3.12:latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: uv sync --dev
+      - run: uv run pytest ...
+```
+
+## How-to: Combining HF and Whisper
+
+When a project needs both HuggingFace embeddings and Whisper STT, build a custom image or use multi-stage:
+
+```dockerfile
+# Option A: FROM ci-hf-base, add Whisper
+FROM ghcr.io/pkuppens/pkuppens/ci-hf-base-3.12:latest
+RUN uv pip install --system faster-whisper
+# ... download Whisper model
+
+# Option B: Multi-stage, merge caches
+# Build from ci-hf and ci-whisper, merge /opt/hf_cache if needed
+```
+
+This is not a delivered image; adapt to your project.
+
+## TTS Note
+
+Whisper STT pipelines may include TTS (text-to-speech). TTS is often client-side. Document in your project whether TTS runs server-side or client-side.
+
+## ghcr.io Validation
+
+1. Go to Actions → Build CI Base Images → Run workflow
+2. If push succeeds, ghcr.io access is OK
+3. If it fails, check repository Settings → Actions → General → Workflow permissions ("Read and write")
+4. Ensure no IP/registry blocklists apply
+
+## Build Locally
+
+```bash
+# From pkuppens/pkuppens repo root
+docker build -f ci-base-images/Dockerfile.ci-base-3.12 -t ci-base-3.12:local .
+# After pushing ci-base, build ci-hf (depends on ci-base-3.12:latest in registry)
+docker build -f ci-base-images/Dockerfile.ci-hf-base-3.12 -t ci-hf-base-3.12:local .
+```

--- a/ci-base-images/download_hf_ci_models.py
+++ b/ci-base-images/download_hf_ci_models.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Pre-download HuggingFace models for ci-hf-base-3.12.
+
+Matches on_prem_rag setup_embedding_models.py --ci models:
+- sentence-transformers/all-MiniLM-L6-v2
+- BAAI/bge-small-en-v1.5
+
+Run with: python download_hf_ci_models.py
+Environment: HF_HOME, TRANSFORMERS_CACHE, SENTENCE_TRANSFORMERS_HOME must be set.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Minimal imports to avoid pulling full llama-index etc.
+try:
+    from sentence_transformers import SentenceTransformer
+    from transformers import AutoModel, AutoTokenizer
+except ImportError as e:
+    raise SystemExit(f"Required packages not installed: {e}") from e
+
+
+def main() -> None:
+    """Download CI embedding models."""
+    hf_home = os.environ.get("HF_HOME", "/opt/hf_cache")
+    transformers_cache = os.environ.get("TRANSFORMERS_CACHE", f"{hf_home}/hub")
+    st_home = os.environ.get("SENTENCE_TRANSFORMERS_HOME", f"{hf_home}/sentence_transformers")
+
+    os.makedirs(hf_home, exist_ok=True)
+    os.makedirs(transformers_cache, exist_ok=True)
+    os.makedirs(st_home, exist_ok=True)
+
+    os.environ["HF_HOME"] = hf_home
+    os.environ["TRANSFORMERS_CACHE"] = transformers_cache
+    os.environ["SENTENCE_TRANSFORMERS_HOME"] = st_home
+
+    # sentence-transformers
+    print("[Download] sentence-transformers/all-MiniLM-L6-v2")
+    SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2", device="cpu")
+
+    # transformers (bge-small)
+    print("[Download] BAAI/bge-small-en-v1.5")
+    AutoModel.from_pretrained("BAAI/bge-small-en-v1.5")
+    AutoTokenizer.from_pretrained("BAAI/bge-small-en-v1.5")
+
+    print("[OK] CI models downloaded")
+
+
+if __name__ == "__main__":
+    main()

--- a/ci-base-images/download_whisper_model.py
+++ b/ci-base-images/download_whisper_model.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+"""Pre-download Whisper base model for ci-whisper-3.12."""
+from faster_whisper import WhisperModel
+
+WhisperModel("base", device="cpu", compute_type="int8")
+print("[OK] Whisper base model downloaded")


### PR DESCRIPTION
## Summary

Add shared CI base images in \ci-base-images/\ for faster CI across pkuppens projects.

## Images

- **ci-base-3.12**: Python 3.12, uv, pytest, ruff, bandit, safety
- **ci-hf-base-3.12**: ci-base + HuggingFace + embedding models (RAG/on_prem_rag)
- **ci-whisper-3.12**: ci-base + faster-whisper + Whisper (STT pipelines)

## Changes

- \.github/workflows/build-ci-base-images.yml\ – build and push to ghcr.io
- \ci-base-images/\ – Dockerfiles, docs, download scripts

Closes #33
Related: pkuppens/on_prem_rag#136

Made with [Cursor](https://cursor.com)