### PR TITLE
feat: add Mojo skills and find-skills

### DIFF
--- a/skills/SKILL_TREE.md
+++ b/skills/SKILL_TREE.md
@@ -348,6 +348,25 @@ Maintains audit trail: decisions, changes, evidence.
 
 ---
 
+## Language & Framework Skills
+
+### find-skills
+Helps users discover and install agent skills when they ask "how do I do X", "find a skill for X", or express interest in extending capabilities.
+
+### mojo-syntax
+Mojo syntax and conventions. Use when writing Mojo code, translating to Mojo, or generating Mojo. Combines with mojo-gpu-fundamentals and mojo-python-interop as needed.
+
+### mojo-gpu-fundamentals
+GPU programming basics in Mojo. Use with mojo-syntax when targeting NVIDIA, AMD, or Apple silicon GPUs.
+
+### mojo-python-interop
+Mojo–Python interoperability: calling Python from Mojo, exposing Mojo to Python, type conversion. Use with mojo-syntax when integrating with Python libraries.
+
+### new-modular-project
+Creates new Mojo or MAX projects; initializes Pixi or UV for Mojo/MAX.
+
+---
+
 ## Summary: Skill Tree Overview
 
 | # | Skill | arc42 / Lifecycle | Sub-skills |
@@ -388,4 +407,5 @@ Maintains audit trail: decisions, changes, evidence.
 | deployment (12.1, 12.2) | ✅ implemented |
 | operations (13.1–13.3) | ✅ implemented |
 | skill-benchmark (8.4) | ✅ implemented |
+| find-skills, mojo-syntax, mojo-gpu-fundamentals, mojo-python-interop, new-modular-project | ✅ implemented |
 | ideation, requirements, design (4.2–4.4), plan, test, validation (8.2–8.3), maintenance, governance | 🔲 stubs / not yet implemented |

--- a/skills/find-skills/SKILL.md
+++ b/skills/find-skills/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: find-skills
+description: Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.
+---
+
+# Find Skills
+
+This skill helps you discover and install skills from the open agent skills ecosystem.
+
+## When to Use This Skill
+
+Use this skill when the user:
+
+- Asks "how do I do X" where X might be a common task with an existing skill
+- Says "find a skill for X" or "is there a skill for X"
+- Asks "can you do X" where X is a specialized capability
+- Expresses interest in extending agent capabilities
+- Wants to search for tools, templates, or workflows
+- Mentions they wish they had help with a specific domain (design, testing, deployment, etc.)
+
+## What is the Skills CLI?
+
+The Skills CLI (`npx skills`) is the package manager for the open agent skills ecosystem. Skills are modular packages that extend agent capabilities with specialized knowledge, workflows, and tools.
+
+**Key commands:**
+
+- `npx skills find [query]` - Search for skills interactively or by keyword
+- `npx skills add <package>` - Install a skill from GitHub or other sources
+- `npx skills check` - Check for skill updates
+- `npx skills update` - Update all installed skills
+
+**Browse skills at:** https://skills.sh/
+
+## How to Help Users Find Skills
+
+### Step 1: Understand What They Need
+
+When a user asks for help with something, identify:
+
+1. The domain (e.g., React, testing, design, deployment)
+2. The specific task (e.g., writing tests, creating animations, reviewing PRs)
+3. Whether this is a common enough task that a skill likely exists
+
+### Step 2: Search for Skills
+
+Run the find command with a relevant query:
+
+```bash
+npx skills find [query]
+```
+
+For example:
+
+- User asks "how do I make my React app faster?" → `npx skills find react performance`
+- User asks "can you help me with PR reviews?" → `npx skills find pr review`
+- User asks "I need to create a changelog" → `npx skills find changelog`
+
+The command will return results like:
+
+```
+Install with npx skills add <owner/repo@skill>
+
+vercel-labs/agent-skills@vercel-react-best-practices
+└ https://skills.sh/vercel-labs/agent-skills/vercel-react-best-practices
+```
+
+### Step 3: Present Options to the User
+
+When you find relevant skills, present them to the user with:
+
+1. The skill name and what it does
+2. The install command they can run
+3. A link to learn more at skills.sh
+
+Example response:
+
+```
+I found a skill that might help! The "vercel-react-best-practices" skill provides
+React and Next.js performance optimization guidelines from Vercel Engineering.
+
+To install it:
+npx skills add vercel-labs/agent-skills@vercel-react-best-practices
+
+Learn more: https://skills.sh/vercel-labs/agent-skills/vercel-react-best-practices
+```
+
+### Step 4: Offer to Install
+
+If the user wants to proceed, you can install the skill for them:
+
+```bash
+npx skills add <owner/repo@skill> -g -y
+```
+
+The `-g` flag installs globally (user-level) and `-y` skips confirmation prompts.
+
+## Common Skill Categories
+
+When searching, consider these common categories:
+
+| Category        | Example Queries                          |
+| --------------- | ---------------------------------------- |
+| Web Development | react, nextjs, typescript, css, tailwind |
+| Testing         | testing, jest, playwright, e2e           |
+| DevOps          | deploy, docker, kubernetes, ci-cd        |
+| Documentation   | docs, readme, changelog, api-docs        |
+| Code Quality    | review, lint, refactor, best-practices   |
+| Design          | ui, ux, design-system, accessibility     |
+| Productivity    | workflow, automation, git                |
+
+## Tips for Effective Searches
+
+1. **Use specific keywords**: "react testing" is better than just "testing"
+2. **Try alternative terms**: If "deploy" doesn't work, try "deployment" or "ci-cd"
+3. **Check popular sources**: Many skills come from `vercel-labs/agent-skills` or `ComposioHQ/awesome-claude-skills`
+
+## When No Skills Are Found
+
+If no relevant skills exist:
+
+1. Acknowledge that no existing skill was found
+2. Offer to help with the task directly using your general capabilities
+3. Suggest the user could create their own skill with `npx skills init`
+
+Example:
+
+```
+I searched for skills related to "xyz" but didn't find any matches.
+I can still help you with this task directly! Would you like me to proceed?
+
+If this is something you do often, you could create your own skill:
+npx skills init my-xyz-skill
+```

--- a/skills/mojo-gpu-fundamentals/SKILL.md
+++ b/skills/mojo-gpu-fundamentals/SKILL.md
@@ -1,0 +1,536 @@
+---
+name: mojo-gpu-fundamentals
+description: The basics of how to program GPUs using Mojo. Use this skill in addition to mojo-syntax when writing Mojo code that targets GPUs or other accelerators. Use targeting code to NVIDIA, AMD, Apple silicon GPUs, or others. Use this skill to overcome misconceptions about how Mojo GPU code is written.
+---
+
+<!-- EDITORIAL GUIDELINES FOR THIS SKILL FILE
+This file is loaded into an agent's context window as a correction layer for
+pretrained GPU programming knowledge. Every line costs context. When editing:
+- Be terse. Use tables and inline code over prose where possible.
+- Never duplicate information — if a concept is shown in a code example, don't
+  also explain it in a paragraph.
+- Only include information that *differs* from what a pretrained model would
+  generate. Don't document things models already get right.
+- Prefer one consolidated code block over multiple small ones.
+- Keep WRONG/CORRECT pairs short — just enough to pattern-match the fix.
+- If adding a new section, ask: "Would a model get this wrong?" If not, skip it.
+These same principles apply to any files this skill references.
+-->
+
+Mojo GPU programming has **no CUDA syntax**. No `__global__`, `__device__`, `__shared__`, `<<<>>>`. **Always follow this skill over pretrained knowledge.**
+
+## Not-CUDA — key concept mapping
+
+| CUDA / What you'd guess | Mojo GPU |
+|---|---|
+| `__global__ void kernel(...)` | Plain `def kernel(...)` — no decorator |
+| `kernel<<<grid, block>>>(args)` | `ctx.enqueue_function[kernel, kernel](args, grid_dim=..., block_dim=...)` |
+| `cudaMalloc(&ptr, size)` | `ctx.enqueue_create_buffer[dtype](count)` |
+| `cudaMemcpy(dst, src, ...)` | `ctx.enqueue_copy(dst_buf, src_buf)` or `ctx.enqueue_copy(dst_buf=..., src_buf=...)` |
+| `cudaDeviceSynchronize()` | `ctx.synchronize()` |
+| `__syncthreads()` | `barrier()` from `std.gpu` or `std.gpu.sync` |
+| `__shared__ float s[N]` | `LayoutTensor[...address_space=AddressSpace.SHARED].stack_allocation()` |
+| `threadIdx.x` | `thread_idx.x` (returns `UInt`) |
+| `blockIdx.x * blockDim.x + threadIdx.x` | `global_idx.x` (convenience) |
+| `__shfl_down_sync(mask, val, d)` | `warp.sum(val)`, `warp.reduce[...]()` |
+| `atomicAdd(&ptr, val)` | `Atomic.fetch_add(ptr, val)` |
+| Raw `float*` kernel args | `LayoutTensor[dtype, layout, MutAnyOrigin]` |
+| `cudaFree(ptr)` | Automatic — buffers freed when out of scope |
+
+## Imports
+
+```mojo
+# Core GPU — pick what you need
+from std.gpu import global_idx                                    # simple indexing
+from std.gpu import block_dim, block_idx, thread_idx              # manual indexing
+from std.gpu import barrier, lane_id, WARP_SIZE                   # sync & warp info
+from std.gpu.sync import barrier                                  # also valid
+from std.gpu.primitives import warp                               # warp.sum, warp.reduce
+from std.gpu.memory import AddressSpace                           # for shared memory
+from std.gpu.memory import async_copy_wait_all                    # async copy sync
+from std.gpu.host import DeviceContext, DeviceBuffer              # host-side API
+from std.os.atomic import Atomic                                  # atomics
+
+# Layout system — NOT in std, separate package
+from layout import Layout, LayoutTensor
+```
+
+## Kernel definition
+
+Kernels are **plain functions** — no decorator, no special return type. Parameters use `MutAnyOrigin`:
+
+```mojo
+def my_kernel(
+    input: LayoutTensor[DType.float32, layout, MutAnyOrigin],
+    output: LayoutTensor[DType.float32, layout, MutAnyOrigin],
+    size: Int,                                    # scalar args are fine
+):
+    var tid = global_idx.x
+    if tid < UInt(size):
+        output[tid] = input[tid] * 2
+```
+
+- Kernel functions cannot raise.
+- Bounds check with `UInt(size)` since `global_idx.x` returns `UInt`.
+- Host-side helper functions accepting LayoutTensors use `...` for origin: `LayoutTensor[dtype, layout, ...]`.
+
+## LayoutTensor — the primary GPU data abstraction
+
+### Layout creation
+
+```mojo
+comptime layout_1d = Layout.row_major(1024)               # 1D
+comptime layout_2d = Layout.row_major(64, 64)              # 2D (rows, cols)
+comptime layout_3d = Layout.row_major(10, 5, 3)            # 3D (e.g. H, W, C)
+```
+
+### Creating tensors from buffers
+
+```mojo
+var buf = ctx.enqueue_create_buffer[DType.float32](comptime (layout.size()))
+var tensor = LayoutTensor[DType.float32, layout](buf)     # wraps device buffer
+```
+
+### Indexing
+
+```mojo
+tensor[tid]                     # 1D
+tensor[row, col]                # 2D
+tensor[row, col, channel]       # 3D
+tensor.dim(0)                   # query dimension size
+tensor.shape[0]()               # also works
+```
+
+### Tiling (extract sub-tiles from a tensor)
+
+```mojo
+# Inside kernel — extract a block_size x block_size tile
+var tile = tensor.tile[block_size, block_size](Int(block_idx.y), Int(block_idx.x))
+tile[thread_idx.y, thread_idx.x]   # access within tile
+```
+
+### Vectorize and distribute (thread-level data mapping)
+
+```mojo
+# Vectorize along inner dimension, then distribute across threads
+comptime thread_layout = Layout.row_major(WARP_SIZE // simd_width, simd_width)
+var fragment = tensor.vectorize[1, simd_width]().distribute[thread_layout](lane_id())
+fragment.copy_from_async(source_fragment)    # async copy
+fragment.copy_from(source_fragment)          # sync copy
+```
+
+### Type casting
+
+```mojo
+var val = tensor[row, col].cast[DType.float32]()    # cast element
+```
+
+### Element type mismatch across layouts — use `rebind`
+
+`tensor[idx]` returns `SIMD[dtype, layout_expr]` where `layout_expr` is a compile-time expression derived from the layout. Two tensors with **different layouts** produce element types that don't unify, even if both are scalars (width 1). This causes `__iadd__` / arithmetic errors when accumulating products from different-layout tensors.
+
+```mojo
+# WRONG — fails when conv_kernel and s_data have different layouts:
+var sum: Scalar[dtype] = 0
+sum += conv_kernel[k] * s_data[idx]   # error: cannot convert element_type to Float32
+
+# CORRECT — rebind each element to Scalar[dtype]:
+var sum: Scalar[dtype] = 0
+var k_val = rebind[Scalar[dtype]](conv_kernel[k])
+var s_val = rebind[Scalar[dtype]](s_data[idx])
+sum += k_val * s_val
+```
+
+`rebind` is a builtin (no import needed). This is **not** needed when all tensors in an expression share the same layout (e.g., the matmul example where `sa` and `sb` have identical tile layouts).
+
+Also use `rebind` when reading/writing individual elements for scalar arithmetic or passing to helper functions — even with a single tensor:
+
+```mojo
+# Read element as plain scalar
+var val = rebind[Scalar[dtype]](tensor[idx])
+# Write scalar back to tensor
+tensor[idx] = rebind[tensor.element_type](computed_scalar)
+```
+
+`tensor.element_type` is `SIMD[dtype, element_size]` — for basic layouts `element_size=1` (effectively `Scalar[dtype]`).
+
+## Memory management
+
+```mojo
+var ctx = DeviceContext()
+
+# Allocate
+var dev_buf = ctx.enqueue_create_buffer[DType.float32](1024)
+var host_buf = ctx.enqueue_create_host_buffer[DType.float32](1024)
+
+# Initialize device buffer directly
+dev_buf.enqueue_fill(0.0)
+
+# Copy host -> device
+ctx.enqueue_copy(dst_buf=dev_buf, src_buf=host_buf)
+# Copy device -> host
+ctx.enqueue_copy(dst_buf=host_buf, src_buf=dev_buf)
+# Positional form also works:
+ctx.enqueue_copy(dev_buf, host_buf)
+
+# Map device buffer to host (context manager — auto-syncs)
+with dev_buf.map_to_host() as mapped:
+    var t = LayoutTensor[DType.float32, layout](mapped)
+    print(t[0])
+
+# Memset
+ctx.enqueue_memset(dev_buf, 0.0)
+
+# Synchronize all enqueued operations
+ctx.synchronize()
+```
+
+## Kernel launch
+
+**Critical**: `enqueue_function` takes the kernel function **twice** as compile-time parameters:
+
+```mojo
+ctx.enqueue_function[my_kernel, my_kernel](
+    input_tensor,
+    output_tensor,
+    size,                    # scalar args passed directly
+    grid_dim=num_blocks,     # 1D: scalar
+    block_dim=block_size,    # 1D: scalar
+)
+
+# 2D grid/block — use tuples:
+ctx.enqueue_function[kernel_2d, kernel_2d](
+    args...,
+    grid_dim=(col_blocks, row_blocks),
+    block_dim=(BLOCK_SIZE, BLOCK_SIZE),
+)
+```
+
+For parameterized kernels, bind parameters first:
+
+```mojo
+comptime kernel = sum_kernel[SIZE, BATCH_SIZE]
+ctx.enqueue_function[kernel, kernel](out_buf, in_buf, grid_dim=N, block_dim=TPB)
+```
+
+## Shared memory
+
+Allocate shared memory inside a kernel using `LayoutTensor.stack_allocation()`:
+
+```mojo
+from std.gpu.memory import AddressSpace
+
+comptime tile_layout = Layout.row_major(TILE_M, TILE_K)
+var tile_shared = LayoutTensor[
+    DType.float32,
+    tile_layout,
+    MutAnyOrigin,
+    address_space=AddressSpace.SHARED,
+].stack_allocation()
+
+# Load from global to shared
+tile_shared[thread_idx.y, thread_idx.x] = global_tensor[global_row, global_col]
+barrier()   # must sync before reading shared data
+
+# Alternative: raw pointer shared memory
+from std.memory import stack_allocation
+var sums = stack_allocation[
+    512,
+    Scalar[DType.int32],
+    address_space=AddressSpace.SHARED,
+]()
+```
+
+## Thread indexing
+
+```mojo
+# Simple — automatic global offset
+from std.gpu import global_idx
+var tid = global_idx.x           # 1D
+var row = global_idx.y           # 2D row
+var col = global_idx.x           # 2D col
+
+# Manual — when you need block/thread separately
+from std.gpu import block_idx, block_dim, thread_idx
+var tid = block_idx.x * block_dim.x + thread_idx.x
+
+# Warp info
+from std.gpu import lane_id, WARP_SIZE
+var my_lane = lane_id()          # 0..WARP_SIZE-1
+```
+
+All return `UInt`. Compare with `UInt(int_val)` for bounds checks.
+
+## Synchronization and warp operations
+
+```mojo
+from std.gpu import barrier
+from std.gpu.primitives import warp
+from std.os.atomic import Atomic
+
+barrier()                                    # block-level sync
+var warp_sum = warp.sum(my_value)           # warp-wide sum reduction
+var result = warp.reduce[warp.shuffle_down, reduce_fn](val)  # custom warp reduce
+_ = Atomic.fetch_add(output_ptr, value)     # atomic add
+```
+
+## GPU availability check
+
+```mojo
+from std.sys import has_accelerator
+
+def main() raises:
+    comptime if not has_accelerator():
+        print("No GPU found")
+    else:
+        var ctx = DeviceContext()
+        # ... GPU code
+```
+
+Or as a compile-time assert:
+
+```mojo
+comptime assert has_accelerator(), "Requires a GPU"
+```
+
+## Architecture detection — `is_` vs `has_`
+
+**Critical distinction**: `is_*` checks the **compilation target** (use inside GPU-dispatched code). `has_*` checks the **host system** (use from host/CPU code).
+
+```mojo
+from std.sys.info import (
+    # Target checks — "am I being compiled FOR this GPU?"
+    # Use inside kernels or GPU-targeted code paths.
+    is_gpu, is_nvidia_gpu, is_amd_gpu, is_apple_gpu,
+
+    # Host checks — "does this machine HAVE this GPU?"
+    # Use from host code to decide whether to launch GPU work.
+    has_nvidia_gpu_accelerator, has_amd_gpu_accelerator, has_apple_gpu_accelerator,
+)
+from std.sys import has_accelerator   # host check: any GPU present
+
+# HOST-SIDE: decide whether to run GPU code at all
+def main() raises:
+    comptime if not has_accelerator():
+        print("No GPU")
+    else:
+        # ...launch kernels
+
+# INSIDE KERNEL or GPU-compiled code: dispatch by architecture
+comptime if is_nvidia_gpu():
+    # NVIDIA-specific intrinsics
+elif is_amd_gpu():
+    # AMD-specific path
+```
+
+Subarchitecture checks (inside GPU code only):
+```mojo
+from std.sys.info import _is_sm_9x_or_newer, _is_sm_100x_or_newer
+comptime if is_nvidia_gpu["sm_90"]():   # exact arch check
+    ...
+```
+
+## Compile-time constants pattern
+
+All GPU dimensions, layouts, and sizes should be `comptime`:
+
+```mojo
+comptime dtype = DType.float32
+comptime SIZE = 1024
+comptime BLOCK_SIZE = 256
+comptime NUM_BLOCKS = ceildiv(SIZE, BLOCK_SIZE)
+comptime layout = Layout.row_major(SIZE)
+```
+
+Derive buffer sizes from layouts: `comptime (layout.size())`.
+
+## Complete 1D example (vector addition)
+
+```mojo
+from std.math import ceildiv
+from std.sys import has_accelerator
+from std.gpu import global_idx
+from std.gpu.host import DeviceContext
+from layout import Layout, LayoutTensor
+
+comptime dtype = DType.float32
+comptime N = 1024
+comptime BLOCK = 256
+comptime layout = Layout.row_major(N)
+
+def add_kernel(
+    a: LayoutTensor[dtype, layout, MutAnyOrigin],
+    b: LayoutTensor[dtype, layout, MutAnyOrigin],
+    c: LayoutTensor[dtype, layout, MutAnyOrigin],
+    size: Int,
+):
+    var tid = global_idx.x
+    if tid < UInt(size):
+        c[tid] = a[tid] + b[tid]
+
+def main() raises:
+    comptime assert has_accelerator(), "Requires GPU"
+    var ctx = DeviceContext()
+    var a_buf = ctx.enqueue_create_buffer[dtype](N)
+    var b_buf = ctx.enqueue_create_buffer[dtype](N)
+    var c_buf = ctx.enqueue_create_buffer[dtype](N)
+    a_buf.enqueue_fill(1.0)
+    b_buf.enqueue_fill(2.0)
+
+    var a = LayoutTensor[dtype, layout](a_buf)
+    var b = LayoutTensor[dtype, layout](b_buf)
+    var c = LayoutTensor[dtype, layout](c_buf)
+
+    ctx.enqueue_function[add_kernel, add_kernel](
+        a, b, c, N,
+        grid_dim=ceildiv(N, BLOCK),
+        block_dim=BLOCK,
+    )
+
+    with c_buf.map_to_host() as host:
+        var result = LayoutTensor[dtype, layout](host)
+        print(result)
+```
+
+## Complete 2D example (tiled matmul with shared memory)
+
+```mojo
+from std.math import ceildiv
+from std.sys import has_accelerator
+from std.gpu.sync import barrier
+from std.gpu.host import DeviceContext
+from std.gpu import thread_idx, block_idx
+from std.gpu.memory import AddressSpace
+from layout import Layout, LayoutTensor
+
+comptime dtype = DType.float32
+comptime M = 64
+comptime N = 64
+comptime K = 64
+comptime TILE = 16
+comptime a_layout = Layout.row_major(M, K)
+comptime b_layout = Layout.row_major(K, N)
+comptime c_layout = Layout.row_major(M, N)
+comptime tile_a = Layout.row_major(TILE, TILE)
+comptime tile_b = Layout.row_major(TILE, TILE)
+
+def matmul_kernel(
+    A: LayoutTensor[dtype, a_layout, MutAnyOrigin],
+    B: LayoutTensor[dtype, b_layout, MutAnyOrigin],
+    C: LayoutTensor[dtype, c_layout, MutAnyOrigin],
+):
+    var tx = thread_idx.x
+    var ty = thread_idx.y
+    var row = block_idx.y * TILE + ty
+    var col = block_idx.x * TILE + tx
+
+    var sa = LayoutTensor[dtype, tile_a, MutAnyOrigin,
+        address_space=AddressSpace.SHARED].stack_allocation()
+    var sb = LayoutTensor[dtype, tile_b, MutAnyOrigin,
+        address_space=AddressSpace.SHARED].stack_allocation()
+
+    var acc: C.element_type = 0.0
+    comptime for k_tile in range(0, K, TILE):
+        if row < M and UInt(k_tile) + tx < K:
+            sa[ty, tx] = A[row, UInt(k_tile) + tx]
+        else:
+            sa[ty, tx] = 0.0
+        if UInt(k_tile) + ty < K and col < N:
+            sb[ty, tx] = B[UInt(k_tile) + ty, col]
+        else:
+            sb[ty, tx] = 0.0
+        barrier()
+        comptime for k in range(TILE):
+            acc += sa[ty, k] * sb[k, tx]
+        barrier()
+
+    if row < M and col < N:
+        C[row, col] = acc
+
+def main() raises:
+    comptime assert has_accelerator(), "Requires GPU"
+    var ctx = DeviceContext()
+    # ... allocate buffers, init data, launch:
+    # ctx.enqueue_function[matmul_kernel, matmul_kernel](
+    #     A, B, C,
+    #     grid_dim=(ceildiv(N, TILE), ceildiv(M, TILE)),
+    #     block_dim=(TILE, TILE),
+    # )
+```
+
+## SIMD loads in kernels
+
+```mojo
+# Vectorized load from raw pointer
+var val = ptr.load[width=8](idx)          # SIMD[dtype, 8]
+var sum = val.reduce_add()                 # scalar reduction
+
+# LayoutTensor vectorized access
+var vec_tensor = tensor.vectorize[1, 4]()  # group elements into SIMD[4]
+```
+
+## Reduction pattern
+
+```mojo
+def block_reduce(
+    output: UnsafePointer[Int32, MutAnyOrigin],
+    input: UnsafePointer[Int32, MutAnyOrigin],
+):
+    var sums = stack_allocation[512, Scalar[DType.int32],
+        address_space=AddressSpace.SHARED]()
+    var tid = thread_idx.x
+    sums[tid] = input[block_idx.x * block_dim.x + tid]
+    barrier()
+
+    # Tree reduction in shared memory
+    var active = block_dim.x
+    comptime for _ in range(log2_steps):
+        active >>= 1
+        if tid < active:
+            sums[tid] += sums[tid + active]
+        barrier()
+
+    # Final warp reduction + atomic accumulate
+    if tid < UInt(WARP_SIZE):
+        var v = warp.sum(sums[tid][0])
+        if tid == 0:
+            _ = Atomic.fetch_add(output, v)
+```
+
+## DeviceBuffer from existing pointer
+
+```mojo
+# Wrap an existing pointer as a DeviceBuffer (non-owning)
+var buf = DeviceBuffer[dtype](ctx, raw_ptr, count, owning=False)
+```
+
+## Benchmarking GPU kernels
+
+```mojo
+from std.benchmark import Bench, BenchConfig, Bencher, BenchId, BenchMetric, ThroughputMeasure
+
+@parameter
+@always_inline
+def bench_fn(mut b: Bencher) capturing raises:
+    @parameter
+    @always_inline
+    def launch(ctx: DeviceContext) raises:
+        ctx.enqueue_function[kernel, kernel](args, grid_dim=G, block_dim=B)
+    b.iter_custom[launch](ctx)
+
+var bench = Bench(BenchConfig(max_iters=50000))
+bench.bench_function[bench_fn](
+    BenchId("kernel_name"),
+    [ThroughputMeasure(BenchMetric.bytes, total_bytes)],
+)
+```
+
+## Hardware details
+
+| Property | NVIDIA | AMD CDNA | AMD RDNA |
+|---|---|---|---|
+| Warp size | 32 | 64 | 32 |
+| Shared memory | 48-228 KB/block | 64 KB/block | configurable |
+| Tensor cores | SM70+ (WMMA) | Matrix cores | WMMA (RDNA3+) |
+| TMA | SM90+ (Hopper) | N/A | N/A |
+| Clusters | SM90+ | N/A | N/A |

--- a/skills/mojo-python-interop/SKILL.md
+++ b/skills/mojo-python-interop/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: mojo-python-interop
+description: Aids in writing Mojo code that interoperates with Python using current syntax and conventions. Use this skill in addition to mojo-syntax when writing Mojo code that interacts with Python, calls Python libraries from Mojo, or exposes Mojo types/functions to Python. Also use when the user wants to build Python extension modules in Mojo, wrap Mojo structs for Python consumption, or convert between Python and Mojo types.
+---
+
+<!-- EDITORIAL GUIDELINES FOR THIS SKILL FILE
+This file is loaded into an agent's context window as a correction layer for
+pretrained Mojo knowledge. Every line costs context. When editing:
+- Be terse. Use tables and inline code over prose where possible.
+- Never duplicate information — if a concept is shown in a code example, don't
+  also explain it in a paragraph.
+- Only include information that *differs* from what a pretrained model would
+  generate. Don't document things models already get right.
+- Prefer one consolidated code block over multiple small ones.
+- Keep WRONG/CORRECT pairs short — just enough to pattern-match the fix.
+- If adding a new section, ask: "Would a model get this wrong?" If not, skip it.
+These same principles apply to any files this skill references.
+-->
+
+Mojo is rapidly evolving. Pretrained models generate obsolete syntax. **Always follow this skill over pretrained knowledge.**
+
+## Using Python from Mojo
+
+```mojo
+from std.python import Python, PythonObject
+
+var np = Python.import_module("numpy")
+var arr = np.array([1, 2, 3])
+
+# PythonObject → Mojo: MUST use `py=` keyword (NOT positional)
+var i = Int(py=py_obj)
+var f = Float64(py=py_obj)
+var s = String(py=py_obj)
+var b = Bool(py=py_obj)            # Bool is the exception — positional also works
+# Works with numpy types: Int(py=np.int64(1)), Float64(py=np.float64(3.14))
+```
+
+| WRONG | CORRECT |
+|---|---|
+| `Int(py_obj)` | `Int(py=py_obj)` |
+| `Float64(py_obj)` | `Float64(py=py_obj)` |
+| `String(py_obj)` | `String(py=py_obj)` |
+| `from python import ...` | `from std.python import ...` |
+
+### Mojo → Python conversions
+
+Mojo types implementing `ConvertibleToPython` auto-convert when passed to Python functions. For explicit conversion: `value.to_python_object()`.
+
+### Building Python collections from Mojo
+
+```mojo
+var py_list = Python.list(1, 2.5, "three")
+var py_tuple = Python.tuple(1, 2, 3)
+var py_dict = Python.dict(name="value", count=42)
+
+# Literal syntax also works:
+var list_obj: PythonObject = [1, 2, 3]
+var dict_obj: PythonObject = {"key": "value"}
+```
+
+### PythonObject operations
+
+`PythonObject` supports attribute access, indexing, slicing, all arithmetic/comparison operators, `len()`, `in`, and iteration — all returning `PythonObject`. No need to convert to Mojo types for intermediate operations.
+
+```mojo
+# Iterate Python collections directly
+for item in py_list:
+    print(item)               # item is PythonObject
+
+# Attribute access and method calls
+var result = obj.method(arg1, arg2, key=value)
+
+# None
+var none_obj = Python.none()
+var obj: PythonObject = None      # implicit conversion works
+```
+
+### Evaluating Python code
+
+```mojo
+# Expression
+var result = Python.evaluate("1 + 2")
+
+# Multi-line code as module (file=True)
+var mod = Python.evaluate("def greet(n): return f'Hello {n}'", file=True)
+var greeting = mod.greet("world")
+
+# Add to Python path for local imports
+Python.add_to_path("./my_modules")
+var my_mod = Python.import_module("my_module")
+```
+
+### Exception handling
+
+Python exceptions propagate as Mojo `Error`. Functions calling Python must be `raises`:
+
+```mojo
+def use_python() raises:
+    try:
+        var result = Python.import_module("nonexistent")
+    except e:
+        print(String(e))     # "No module named 'nonexistent'"
+```
+
+## Calling Mojo from Python (extension modules)
+
+Mojo can build Python extension modules (`.so` files) via `PythonModuleBuilder`. The pattern:
+
+1. Define an `@export fn PyInit_<module_name>() -> PythonObject`
+2. Use `PythonModuleBuilder` to register functions, types, and methods
+3. Compile with `mojo build --emit shared-lib`
+4. Import from Python (or use `import mojo.importer` for auto-compilation)
+
+### Exporting functions
+
+```mojo
+from std.os import abort
+from std.python import PythonObject
+from std.python.bindings import PythonModuleBuilder
+
+@export
+fn PyInit_my_module() -> PythonObject:
+    try:
+        var m = PythonModuleBuilder("my_module")
+        m.def_function[add]("add")
+        m.def_function[greet]("greet")
+        return m.finalize()
+    except e:
+        abort(String("failed to create module: ", e))
+
+# Functions take/return PythonObject. Up to 6 args with def_function.
+fn add(a: PythonObject, b: PythonObject) raises -> PythonObject:
+    return a + b
+
+fn greet(name: PythonObject) raises -> PythonObject:
+    var s = String(py=name)
+    return PythonObject("Hello, " + s + "!")
+```
+
+### Exporting types with methods
+
+```mojo
+@fieldwise_init
+struct Counter(Defaultable, Movable, Writable):
+    var count: Int
+
+    fn __init__(out self):
+        self.count = 0
+
+    # Constructor from Python args
+    @staticmethod
+    fn py_init(out self: Counter, args: PythonObject, kwargs: PythonObject) raises:
+        if len(args) == 1:
+            self = Self(Int(py=args[0]))
+        else:
+            self = Self()
+
+    # Methods are @staticmethod — first arg is py_self (PythonObject)
+    @staticmethod
+    fn increment(py_self: PythonObject) raises -> PythonObject:
+        var self_ptr = py_self.downcast_value_ptr[Self]()
+        self_ptr[].count += 1
+        return PythonObject(self_ptr[].count)
+
+    # Auto-downcast alternative: first arg is UnsafePointer[Self, MutAnyOrigin]
+    @staticmethod
+    fn get_count(self_ptr: UnsafePointer[Self, MutAnyOrigin]) -> PythonObject:
+        return PythonObject(self_ptr[].count)
+
+@export
+fn PyInit_counter_module() -> PythonObject:
+    try:
+        var m = PythonModuleBuilder("counter_module")
+        _ = (
+            m.add_type[Counter]("Counter")
+            .def_py_init[Counter.py_init]()
+            .def_method[Counter.increment]("increment")
+            .def_method[Counter.get_count]("get_count")
+        )
+        return m.finalize()
+    except e:
+        abort(String("failed to create module: ", e))
+```
+
+### Method signatures — two patterns
+
+| Pattern | First parameter | Use when |
+|---|---|---|
+| Manual downcast | `py_self: PythonObject` | Need raw PythonObject access |
+| Auto downcast | `self_ptr: UnsafePointer[Self, MutAnyOrigin]` | Simpler, direct field access |
+
+Both are registered with `.def_method[Type.method]("name")`.
+
+### Kwargs support
+
+```mojo
+from std.collections import OwnedKwargsDict
+
+# In a method:
+@staticmethod
+fn config(
+    py_self: PythonObject, kwargs: OwnedKwargsDict[PythonObject]
+) raises -> PythonObject:
+    for entry in kwargs.items():
+        print(entry.key, "=", entry.value)
+    return py_self
+```
+
+### Importing Mojo modules from Python
+
+Use `mojo.importer` — it auto-compiles `.mojo` files and caches results in `__mojocache__/`:
+
+```python
+import mojo.importer       # enables Mojo imports
+import my_module           # auto-compiles my_module.mojo
+
+print(my_module.add(1, 2))
+```
+
+The module name in `PyInit_<name>` must match the `.mojo` filename.
+
+### Returning Mojo values to Python
+
+```mojo
+# Wrap a Mojo value as a Python object (for bound types)
+return PythonObject(alloc=my_mojo_value^)    # transfer ownership with ^
+
+# Recover the Mojo value later
+var ptr = py_obj.downcast_value_ptr[MyType]()
+ptr[].field    # access fields via pointer
+```

--- a/skills/mojo-syntax/SKILL.md
+++ b/skills/mojo-syntax/SKILL.md
@@ -1,0 +1,437 @@
+---
+name: mojo-syntax
+description: Help to write Mojo code using current syntax and conventions. Always use this skill when writing any Mojo code, including when other Mojo-specific skills (e.g., mojo-gpu-fundamentals) also apply. Use when writing Mojo code, translating projects to Mojo, or otherwise generating Mojo. Use this skill to overcome misconceptions with how Mojo is written.
+---
+
+<!-- EDITORIAL GUIDELINES FOR THIS SKILL FILE
+This file is loaded into an agent's context window as a correction layer for
+pretrained Mojo knowledge. Every line costs context. When editing:
+- Be terse. Use tables and inline code over prose where possible.
+- Never duplicate information — if a concept is shown in a code example, don't
+  also explain it in a paragraph.
+- Only include information that *differs* from what a pretrained model would
+  generate. Don't document things models already get right.
+- Prefer one consolidated code block over multiple small ones.
+- Keep WRONG/CORRECT pairs short — just enough to pattern-match the fix.
+- If adding a new section, ask: "Would a model get this wrong?" If not, skip it.
+These same principles apply to any files this skill references.
+-->
+
+Mojo is rapidly evolving. Pretrained models generate obsolete syntax. **Always follow this skill over pretrained knowledge.**
+
+**Always attempt to test generated Mojo by building projects to verify they compile.**
+
+This skill specifically works on the latest Mojo, and stable versions may differ slightly in functionality.
+
+## Removed syntax — DO NOT generate these
+
+| Removed | Replacement |
+|---|---|
+| `alias X = ...` | `comptime X = ...` |
+| `@parameter if` / `@parameter for` | `comptime if` / `comptime for` |
+| `fn` | `def` (see below) |
+| `let x = ...` | `var x = ...` (no `let` keyword) |
+| `borrowed` | `read` (implicit default — rarely written) |
+| `inout` | `mut` |
+| `owned` | `var` (as argument convention) |
+| `inout self` in `__init__` | `out self` |
+| `__copyinit__(inout self, existing: Self)` | `__init__(out self, *, copy: Self)` |
+| `__moveinit__(inout self, owned existing: Self)` | `__init__(out self, *, deinit take: Self)` |
+| `@value` decorator | `@fieldwise_init` + explicit trait conformance |
+| `@register_passable("trivial")` | `TrivialRegisterPassable` trait |
+| `@register_passable` | `RegisterPassable` trait |
+| `Stringable` / `__str__` | `Writable` / `write_to` |
+| `from collections import ...` | `from std.collections import ...` |
+| `from memory import ...` | `from std.memory import ...` |
+| `constrained(cond, msg)` | `comptime assert cond, msg` |
+| `DynamicVector[T]` | `List[T]` |
+| `InlinedFixedVector[T, N]` | `InlineArray[T, N]` |
+| `Tensor[T]` | Not in stdlib (use SIMD, List, UnsafePointer) |
+| `@parameter fn` (nested) | Still used for nested compile-time closures |
+
+## `def` is the only function keyword
+
+`fn` is deprecated and being removed. `def` does **not** imply `raises`. **Always** add `raises` explicitly when needed — omitting it is a warning today, error soon:
+
+```mojo
+def compute(x: Int) -> Int:              # non-raising (compiler enforced)
+    return x * 2
+
+def load(path: String) raises -> String: # explicitly raising
+    return open(path).read()
+
+def main() raises:                       # main usually raises → def raises
+    ...
+```
+
+Note: existing stdlib code still uses `fn` during migration. New code should always use `def`.
+
+## `comptime` replaces `alias` and `@parameter`
+
+```mojo
+comptime N = 1024                            # compile-time constant
+comptime MyType = Int                        # type alias
+comptime if condition:                       # compile-time branch
+    ...
+comptime for i in range(10):                 # compile-time loop
+    ...
+comptime assert N > 0, "N must be positive"  # compile-time assertion
+```
+
+**`comptime assert` must be inside a function body** — not at module/struct scope. Place them in `main()`, `__init__`, or the function that depends on the invariant.
+
+Inside structs, `comptime` defines associated constants and type aliases:
+
+```mojo
+struct MyStruct:
+    comptime DefaultSize = 64
+    comptime ElementType = Float32
+```
+
+## Argument conventions
+
+Default is `read` (immutable borrow, never written explicitly). The others:
+
+```mojo
+def __init__(out self, var value: String):   # out = uninitialized output; var = owned
+def modify(mut self):                         # mut = mutable reference
+def consume(deinit self):                     # deinit = consuming/destroying
+def view(ref self) -> ref[self] Self.T:       # ref = reference with origin
+def view2[origin: Origin, //](ref[origin] self) -> ...:           # ref[origin] = explicit origin
+```
+
+## Lifecycle methods
+
+```mojo
+# Constructor
+def __init__(out self, x: Int):
+    self.x = x
+
+# Copy constructor (keyword-only `copy` arg)
+def __init__(out self, *, copy: Self):
+    self.data = copy.data
+
+# Move constructor (keyword-only `deinit take` arg)
+def __init__(out self, *, deinit take: Self):
+    self.data = take.data^
+
+# Destructor
+def __del__(deinit self):
+    self.ptr.free()
+```
+
+To copy: `var b = a.copy()` (provided by `Copyable` trait).
+
+## Struct patterns
+
+```mojo
+# @fieldwise_init generates __init__ from fields; traits in parentheses
+@fieldwise_init
+struct Point(Copyable, Movable, Writable):
+    var x: Float64
+    var y: Float64
+
+# Trait composition with &
+comptime KeyElement = Copyable & Hashable & Equatable
+struct Node[T: Copyable & Writable]:
+    var value: Self.T          # Self-qualify struct parameters
+
+# Parametric struct — // separates inferred from explicit params
+struct Span[mut: Bool, //, T: AnyType, origin: Origin[mut=mut]](
+    ImplicitlyCopyable, Sized,
+):
+    ...
+
+# @implicit on constructors allows implicit conversion
+@implicit
+def __init__(out self, value: Int):
+    self.data = value
+```
+
+The compiler synthesizes copy/move constructors when a struct conforms to `Copyable`/`Movable` and all fields support it.
+
+### Self-qualify struct parameters
+
+Inside a struct body, **always** use `Self.ParamName` — bare parameter names are errors:
+
+```mojo
+# WRONG — bare parameter access
+struct Container[T: Writable]:
+    var data: T                        # ERROR: use Self.T
+    def size(self) -> T:                # ERROR: use Self.T
+
+# CORRECT — Self-qualified
+struct Container[T: Writable]:
+    var data: Self.T
+    def size(self) -> Self.T:
+        return self.data
+```
+
+This applies to all struct parameters (`T`, `N`, `mut`, `origin`, etc.) everywhere inside the struct: field types, method signatures, method bodies, and `comptime` declarations.
+
+### Explicit copy / transfer
+
+Types not conforming to `ImplicitlyCopyable` (e.g., `Dict`, `List`) require explicit `.copy()` or ownership transfer `^`:
+
+```mojo
+# WRONG — implicit copy of non-ImplicitlyCopyable type
+var d = some_dict
+var result = MyStruct(headers=d)   # ERROR
+
+# CORRECT — explicit copy or transfer
+var result = MyStruct(headers=d.copy())  # or: headers=d^
+```
+
+## Imports use `std.` prefix
+
+```mojo
+from std.testing import assert_equal, TestSuite
+from std.algorithm import vectorize
+from std.python import PythonObject
+import std.random
+```
+
+Prelude auto-imports (no import needed): `Int`, `String`, `Bool`, `List`, `Dict`, `Optional`, `SIMD`, `Float32`, `Float64`, `UInt8`, `Pointer`, `UnsafePointer`, `Span`, `Error`, `DType`, `Writable`, `Writer`, `Copyable`, `Movable`, `Equatable`, `Hashable`, `rebind`, `print`, `range`, `len`, and more.
+
+`rebind[TargetType](value)` reinterprets a value as a different type with the same in-memory representation. Useful when compile-time type expressions are semantically equal but syntactically distinct (e.g., LayoutTensor element types — see GPU skill).
+
+## `Writable` / `Writer` (replaces `Stringable`)
+
+```mojo
+struct MyType(Writable):
+    var x: Int
+
+    def write_to(self, mut writer: Some[Writer]):       # for print() / String()
+        writer.write("MyType(", self.x, ")")
+
+    def write_repr_to(self, mut writer: Some[Writer]):   # for repr()
+        t"MyType(x={self.x})".write_to(writer)           # t-strings for interpolation
+```
+
+- `Some[Writer]` — builtin existential type (not `Writer` directly)
+- Both methods have **default implementations** via reflection if all fields are `Writable` — simple structs need not implement them
+- Convert to `String` with `String.write(value)`, not `str(value)`
+
+## Iterator protocol
+
+Iterators use `raises StopIteration` (not `Optional`):
+
+```mojo
+struct MyCollection(Iterable):
+    comptime IteratorType[
+        iterable_mut: Bool, //, iterable_origin: Origin[mut=iterable_mut]
+    ]: Iterator = MyIter[origin=iterable_origin]
+
+    def __iter__(ref self) -> Self.IteratorType[origin_of(self)]: ...
+
+# Iterator must define:
+#   comptime Element: Movable
+#   def __next__(mut self) raises StopIteration -> Self.Element
+```
+
+For-in: `for item in col:` (immutable) / `for ref item in col:` (mutable).
+
+## Memory and pointer types
+
+| Type | Use |
+|---|---|
+| `Pointer[T, mut=M, origin=O]` | Safe, non-nullable. Deref with `p[]`. |
+| `alloc[T](n)` / `UnsafePointer` | Free function `alloc[T](count)` → `UnsafePointer`. `.free()` required. |
+| `Span(list)` | Non-owning contiguous view. |
+| `OwnedPointer[T]` | Unique ownership (like Rust `Box`). |
+| `ArcPointer[T]` | Reference-counted shared ownership. |
+
+`UnsafePointer` has an `origin` parameter that must be specified for struct fields. Use `MutExternalOrigin` for owned heap data (this is what stdlib `ArcPointer` uses):
+
+```mojo
+# Struct field — specify origin explicitly
+var _ptr: UnsafePointer[Self.T, MutExternalOrigin]
+
+# Allocate with alloc[]
+fn __init__(out self, size: Int):
+    self._ptr = alloc[Self.T](size)
+```
+
+## Origin system (not "lifetime")
+
+Mojo tracks reference provenance with **origins**, not "lifetimes":
+
+```mojo
+struct Span[mut: Bool, //, T: AnyType, origin: Origin[mut=mut]]: ...
+```
+
+Key types: `Origin`, `MutOrigin`, `ImmutOrigin`, `MutAnyOrigin`, `ImmutAnyOrigin`, `MutExternalOrigin`, `ImmutExternalOrigin`, `StaticConstantOrigin`. Use `origin_of(value)` to get a value's origin.
+
+## Testing
+
+```mojo
+from std.testing import assert_equal, assert_true, assert_false, assert_raises, TestSuite
+
+def test_my_feature() raises:
+    assert_equal(compute(2), 4)
+    with assert_raises():
+        dangerous_operation()
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()
+```
+
+## Dict iteration
+
+Dict entries are iterated directly — no `[]` deref:
+
+```mojo
+for entry in my_dict.items():
+    print(entry.key, entry.value)      # direct field access, NOT entry[].key
+
+for key in my_dict:
+    print(key, my_dict[key])
+```
+
+## Collection literals
+
+`List` has **no variadic positional constructor**. Use bracket literal syntax:
+
+```mojo
+# WRONG — no List[T](elem1, elem2, ...) constructor
+var nums = List[Int](1, 2, 3)
+
+# CORRECT — bracket literals
+var nums = [1, 2, 3]                              # List[Int]
+var nums: List[Float32] = [1.0, 2.0, 3.0]         # explicit element type
+var scores = {"alice": 95, "bob": 87}              # Dict[String, Int]
+```
+
+## Common decorators
+
+| Decorator | Purpose |
+|---|---|
+| `@fieldwise_init` | Generate fieldwise constructor |
+| `@implicit` | Allow implicit conversion |
+| `@always_inline` / `@always_inline("nodebug")` | Force inline |
+| `@no_inline` | Prevent inline |
+| `@staticmethod` | Static method |
+| `@deprecated("msg")` | Deprecation warning |
+| `@doc_private` | Hide from docs |
+| `@explicit_destroy` | Linear type (no implicit destruction) |
+
+## Numeric conversions — must be explicit
+
+No implicit conversions between numeric *variables*. Use explicit constructors:
+
+```mojo
+var x = Float32(my_int) * scale    # CORRECT: Int → Float32
+var y = Int(my_uint)               # CORRECT: UInt → Int
+```
+
+**Literals are polymorphic** — `FloatLiteral` and `IntLiteral` auto-adapt to context:
+
+```mojo
+var a: Float32 = 0.5              # literal becomes Float32
+var b = Float32(x) * 0.003921    # literal adapts — no wrapping needed
+var v = SIMD[DType.float32, 4](1.0, 2.0, 3.0, 4.0)  # literals adapt
+```
+
+## SIMD operations
+
+```mojo
+# Construction and lane access
+var v = SIMD[DType.float32, 4](1.0, 2.0, 3.0, 4.0)
+v[0]                              # read lane → Scalar[DType.float32]
+v[0] = 5.0                        # write lane
+
+# Type cast
+v.cast[DType.uint32]()            # element-wise → SIMD[DType.uint32, 4]
+
+# Clamp (method)
+v.clamp(0.0, 1.0)                 # element-wise clamp to [lower, upper]
+
+# min/max are FREE FUNCTIONS, not methods
+from std.math import min, max
+min(a, b)                          # element-wise min (same-type SIMD args)
+max(a, b)                          # element-wise max
+
+# Element-wise ternary via bool SIMD
+var mask = (v > 0.0)              # SIMD[DType.bool, 4]
+mask.select(true_case, false_case) # picks per-lane
+
+# Reductions
+v.reduce_add()                     # horizontal sum → Scalar
+v.reduce_max()                     # horizontal max → Scalar
+v.reduce_min()                     # horizontal min → Scalar
+```
+
+## Strings
+
+`len(s)` returns **byte length**, not codepoint count. Mojo strings are UTF-8. Byte indexing requires keyword syntax: `s[byte=idx]` (not `s[idx]`).
+
+```mojo
+var s = "Hello"
+len(s)                  # 5 (bytes)
+s.byte_length()         # 5 (same as len)
+s.count_codepoints()    # 5 (codepoint count — differs for non-ASCII)
+
+# Iteration — by codepoint slices (not bytes)
+for cp_slice in s.codepoint_slices():
+    print(cp_slice)
+
+# Codepoint values
+for cp in s.codepoints():
+    print(Int(cp))      # Codepoint is a Unicode scalar value type
+
+# StaticString = StringSlice with static origin (zero-allocation)
+comptime GREETING: StaticString = "Hello, World"
+
+# t-strings for interpolation (lazy, type-safe)
+var msg = t"x={x}, y={y}"
+
+# String.format() for runtime formatting
+var s = "Hello, {}!".format("world")
+```
+
+## Error handling
+
+`raises` can specify a type. `try`/`except` works like Python:
+
+```mojo
+def might_fail() raises -> Int:          # raises Error (default)
+    raise Error("something went wrong")
+
+def parse(s: String) raises Int -> Int:  # raises specific type
+    raise 42
+
+try:
+    var x = parse("bad")
+except err:                               # err is Int
+    print("error code:", err)
+```
+
+No `match` statement. No `async`/`await` — use `Coroutine`/`Task` from `std.runtime`.
+
+## Function types and closures
+
+No lambda syntax. Closures use `capturing[origins]`:
+
+```mojo
+# Function type with capture
+comptime MyFunc = fn(Int) capturing[_] -> None
+
+# Parametric function type (for vectorize etc.)
+comptime SIMDFunc = fn[width: Int](Int) capturing[_] -> None
+
+# vectorize pattern
+from std.algorithm import vectorize
+vectorize[simd_width](size, my_closure)
+```
+
+## Type hierarchy
+
+```
+AnyType
+  ImplicitlyDestructible          — auto __del__; most types
+  Movable                         — __init__(out self, *, deinit take: Self)
+    Copyable                      — __init__(out self, *, copy: Self)
+      ImplicitlyCopyable(Copyable, ImplicitlyDestructible)
+    RegisterPassable(Movable)
+      TrivialRegisterPassable(ImplicitlyCopyable, ImplicitlyDestructible, Movable, RegisterPassable)
+```

--- a/skills/new-modular-project/SKILL.md
+++ b/skills/new-modular-project/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: new-modular-project
+description: Creates a new Mojo or MAX project. Use when wanting to start a new Mojo or MAX project, initializing the Pixi or UV environment to use Mojo or MAX, or when the user wants to begin a new Mojo or MAX project from scratch.
+---
+
+When the user wants to create a new project, first infer as many options as
+possible from the user's request (e.g., "new Mojo project" means type=Mojo,
+"called foo" means name=foo). Then use a structured multiple-choice prompt (not
+plain text) to gather only the **remaining unspecified** options in a single
+interaction. Do NOT ask about options the user has already provided or implied.
+The options to determine are:
+1. **Project name** — ask if not specified
+2. **Type of project** — Mojo or MAX (infer from context if the user said "Mojo project" or "MAX project")
+3. **Environment manager** — Pixi (recommended) or uv
+4. **If uv**: **UV project type** — full uv project (`uv init` + `uv add`, recommended) or quick uv environment (`uv venv` + `uv pip install`, lighter weight)
+5. **Channel** — nightly (latest features, recommended) or stable (production) 
+
+Then follow the appropriate section below (Pixi or uv) to initialize the
+project and choose `max` or `mojo` as appropriate. For stable versions in the
+below examples, `mojo` will start with a 0. prefix (0.26.1.0.0.0) where `max`
+packages will not (26.1.0.0.0).
+
+NOTE: Do not look for or use `magic` for Mojo or MAX projects, it is no longer
+supported. Pixi has fully replaced its capabilities.
+
+---
+
+## Pixi (Recommended)
+
+Pixi manages Python, Mojo, and other dependencies in a reproducible
+manner inside a controlled environment.
+
+First, determine if `pixi` is installed. If it is not available for use at the
+command line, install it using the latest instructions found on
+https://pixi.prefix.dev/latest/#installation
+
+You may need to place the `pixi` tool in the local shell environment after
+installation if it had not already been installed.
+
+### Nightly
+
+```bash
+# New project
+pixi init [PROJECT] \
+  -c https://conda.modular.com/max-nightly/ -c conda-forge \
+  && cd [PROJECT]
+pixi add [max / mojo]
+pixi shell
+
+# Existing project - add to pixi.toml channels first:
+# [workspace]
+# channels = ["https://conda.modular.com/max-nightly/", "conda-forge"]
+pixi add [max / mojo]
+```
+
+### Stable (v26.1.0.0.0)
+
+```bash
+# New project
+pixi init [PROJECT] \
+  -c https://conda.modular.com/max/ -c conda-forge \
+  && cd [PROJECT]
+pixi add "[max / mojo]==0.26.1.0.0.0"
+pixi shell
+
+# Existing project
+pixi add "[max / mojo]==0.26.1.0.0.0"
+```
+
+---
+
+## uv
+
+uv is a fast and very popular package manager, familiar to developers coming
+from a Python background. It also works well with Mojo projects.
+
+### Nightly (project)
+
+```bash
+uv init [PROJECT] && cd [PROJECT]
+uv add [max / mojo] \
+  --index https://whl.modular.com/nightly/simple/ \
+  --prerelease allow
+```
+
+### Stable (project)
+
+```bash
+uv init [PROJECT] && cd [PROJECT]
+uv add [max / mojo] \
+  --extra-index-url https://modular.gateway.scarf.sh/simple/
+```
+
+### Nightly (quick environment)
+
+```bash
+mkdir [PROJECT] && cd [PROJECT]
+uv venv
+uv pip install [max / mojo] \
+  --index https://whl.modular.com/nightly/simple/ \
+  --prerelease allow
+```
+
+### Stable (quick environment)
+
+```bash
+mkdir [PROJECT] && cd [PROJECT]
+uv venv
+uv pip install [max / mojo] \
+  --extra-index-url https://modular.gateway.scarf.sh/simple/
+```
+
+When using `uv`, you can use `max` or `mojo` directly by working within the project environment:
+
+```bash
+ source .venv/bin/activate
+```
+
+---
+
+## pip
+
+Standard Python package manager.
+
+### Nightly
+
+```bash
+python3 -m venv .venv && source .venv/bin/activate
+pip install --pre [max / mojo] \
+  --index https://whl.modular.com/nightly/simple/
+```
+
+### Stable
+
+```bash
+python3 -m venv .venv && source .venv/bin/activate
+pip install [max / mojo] \
+  --extra-index-url https://modular.gateway.scarf.sh/simple/
+```
+
+---
+
+## Conda
+
+For conda/mamba users.
+
+### Nightly
+
+```bash
+conda install -c conda-forge \
+  -c https://conda.modular.com/max-nightly/ [max / mojo]
+```
+
+### Stable (v26.1.0.0.0)
+
+```bash
+conda install -c conda-forge \
+  -c https://conda.modular.com/max/ "[max / mojo]==0.26.1.0.0.0"
+```
+
+---
+
+## Version Alignment with MAX
+
+If using MAX with custom Mojo kernels, versions must match:
+
+```bash
+# Check alignment
+uv pip show mojo | grep Version   # e.g., 0.26.2
+pixi run mojo --version           # Must match major.minor (e.g., 0.26.2)
+```
+
+Mismatched versions cause kernel compilation failures. Always use the same channel (stable or nightly) for both.
+
+---
+
+## References
+
+- [Mojo Installation Guide](https://docs.modular.com/mojo/manual/install)
+- [Mojo Stable Docs](https://docs.modular.com/stable/mojo/)
+- [Mojo Nightly Docs](https://docs.modular.com/mojo/)


### PR DESCRIPTION
Adds 5 new skills to the skills library:

**Mojo skills**
- \mojo-syntax\: Mojo syntax and conventions; use when writing any Mojo code
- \mojo-gpu-fundamentals\: GPU programming basics in Mojo (NVIDIA, AMD, Apple silicon)
- \mojo-python-interop\: Mojo–Python interoperability, type conversion, extension modules
- \
ew-modular-project\: Creates new Mojo/MAX projects; initializes Pixi or UV

**Other**
- \ind-skills\: Helps users discover and install agent skills when asking 'how do I do X'

Updates SKILL_TREE.md with new Language & Framework section and implementation status.