### PR TITLE
#28: Integrate sir-read-a-lot arch skills into pkuppens/skills/architecture

### DIFF
--- a/docs/skills/audit-results.md
+++ b/docs/skills/audit-results.md
@@ -89,16 +89,16 @@ Audit of 82+ skill files across workspace locations. Canonical set: `pkuppens/sk
 
 | Skill dir | Canonical equivalent | Action |
 |-----------|----------------------|--------|
-| arch-scan | architecture-document-existing | Merge (#28) |
-| arch-adr | architecture-decisions | Merge (#28) |
-| arch-component | architecture-building-blocks | Merge (#28) |
-| arch-abstraction | architecture-building-blocks | Merge (#28) |
-| arch-runtime-flow | architecture (3.4 runtime) | Merge (#28) |
-| arch-user-flow | design-consult | Merge (#28) |
-| arch-refactor | implementation-refactor | Cross-ref (#28) |
-| arch-rules | architecture-crosscutting | Merge (#28) |
-| arch-migrate | architecture-decisions | Merge (#28) |
-| arch-definition | architecture-glossary | Merge (#28) |
+| arch-scan | architecture-document-existing | ✅ Merged (#28) |
+| arch-adr | architecture-decisions | ✅ Merged (#28) |
+| arch-component | architecture-building-blocks | ✅ Merged (#28) |
+| arch-abstraction | architecture-building-blocks | ✅ Merged (#28) |
+| arch-runtime-flow | architecture-runtime (new) | ✅ Merged (#28) |
+| arch-user-flow | design-consult | ✅ Merged (#28) |
+| arch-refactor | architecture-decisions (AMI) | ✅ Cross-ref (#28) |
+| arch-rules | architecture-crosscutting (new) | ✅ Merged (#28) |
+| arch-migrate | architecture-decisions | ✅ Merged (#28) |
+| arch-definition | architecture-glossary (new) | ✅ Merged (#28) |
 
 ### 1.5 babblr
 

--- a/skills/COOPERATION.md
+++ b/skills/COOPERATION.md
@@ -40,8 +40,10 @@ The [architecture](architecture/SKILL.md) orchestrator routes by mode:
 | Mode | When | Sub-skills (sequence) |
 |------|------|------------------------|
 | **Initial** | Greenfield project | architecture-solution-strategy → architecture-building-blocks |
-| **Retrofitting** | Undocumented codebase | architecture-document-existing |
+| **Retrofitting** | Undocumented codebase | architecture-document-existing (→ architecture-runtime, architecture-building-blocks for delegation) |
 | **Evolving** | Change or extend | architecture-decisions → architecture-risks-debt (as needed) |
+
+Also: architecture-runtime (flows), architecture-crosscutting (rules), architecture-glossary (terms).
 
 ### When to trigger architecture
 

--- a/skills/SKILL_TREE.md
+++ b/skills/SKILL_TREE.md
@@ -398,7 +398,7 @@ Creates new Mojo or MAX projects; initializes Pixi or UV for Mojo/MAX.
 | Skill | Status |
 | skill-creation | ✅ implemented |
 | issue-workflow (5.x) | ✅ implemented |
-| architecture (3.x) | ✅ implemented (partial; sir-read-a-lot merge pending) |
+| architecture (3.x) | ✅ implemented (#28: sir-read-a-lot arch skills merged) |
 | design (4.1) | ✅ implemented |
 | implementation (7.1) | ✅ implemented |
 | validation (8.1) | ✅ implemented |

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -66,18 +66,12 @@ Output follows the sub-skill(s) invoked. Orchestrator output summarizes mode and
 - **Plan / Ask:** Invoked when planning a new system, asking about ADRs, or scoping architectural changes.
 - **COOPERATION.md:** See architecture flows for when to trigger and how sub-skills compose.
 
-## Related skills (pending merge — tracked in #28)
+## Additional sub-skills
 
-The following richer skills exist in `sir-read-a-lot/.claude/skills/` and are pending integration:
+| Sub-skill | When |
+|-----------|------|
+| [architecture-runtime](architecture-runtime/SKILL.md) | Document technical execution paths, sequences |
+| [architecture-crosscutting](architecture-crosscutting/SKILL.md) | Define dependency rules, layer boundaries, architecture tests |
+| [architecture-glossary](architecture-glossary/SKILL.md) | Maintain ubiquitous language, resolve terminology |
 
-| sir-read-a-lot skill | Adds to |
-|---------------------|---------|
-| `arch-abstraction` | Documents abstraction layers, contracts, maturity state, allowed implementations |
-| `arch-rules` | Defines enforceable dependency rules and proposes architecture tests |
-| `arch-refactor` | Plans AMI (Architecture Migration Increment) with seams-first strategy and rollback |
-| `arch-migrate` | Manages AMI program: `98-migration-plan.md` + `97-migration-log.md` |
-| `arch-definition` | Manages ubiquitous language (DDD glossary), synonym groups, validation |
-| `arch-runtime-flow` | Documents technical execution paths with sequence diagrams |
-| `arch-user-flow` | Documents user journeys through UI |
-
-Until merged, use these skills directly from `sir-read-a-lot/.claude/skills/` for the listed capabilities.
+These can be invoked from architecture-document-existing during retrofitting, or directly when needed.

--- a/skills/architecture/architecture-building-blocks/SKILL.md
+++ b/skills/architecture/architecture-building-blocks/SKILL.md
@@ -41,8 +41,17 @@ Write or append to `docs/architecture/05-building-blocks.md`:
 [Inner structure: sub-blocks or modules]
 ```
 
+## Component documentation (retrofitting)
+
+When documenting *existing* components (from architecture-document-existing scan), create `docs/architecture/components/<name>.md` with: Purpose & responsibilities; Public interfaces (API, events, signatures); Dependencies; Data (schemas, tables); Runtime interactions; Errors/retries; Tests; Observability; Links to abstractions and ADRs. Component = concrete implementation (e.g. `WhisperService`); abstraction = conceptual boundary (e.g. "Transcription Provider").
+
+## Abstraction documentation (retrofitting)
+
+When documenting *existing* abstractions, create `docs/architecture/abstractions/<name>.md` with: Intent and scope; Contract (interfaces, invariants); Allowed implementations; Maturity state (Concrete/Abstract/Mixed/Missing/Proposed); Anti-corruption rules; Links to components. Prefer "protocol + vendor adapter" pattern.
+
 ## Integration
 
 - Run after [architecture-solution-strategy](../architecture-solution-strategy/SKILL.md) in Initial mode.
+- Component/abstraction docs: used when [architecture-document-existing](../architecture-document-existing/SKILL.md) delegates.
 - Informs [architecture-consult](../architecture-consult/SKILL.md) for placement.
 - Parent: [architecture](../SKILL.md) orchestrator.

--- a/skills/architecture/architecture-crosscutting/SKILL.md
+++ b/skills/architecture/architecture-crosscutting/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: architecture-crosscutting
+description: Documents crosscutting concepts: dependency rules, layering, and architecture tests. Use when enforcing constraints or detecting architecture drift; produces arc42 §8 content.
+---
+
+# Architecture Crosscutting
+
+Documents and enforces architectural constraints: dependency rules, layer boundaries, and architecture test proposals. Aligns with arc42 §8 (crosscutting concepts).
+
+## When to use
+
+- After identifying layering or dependency patterns in code
+- When architecture drift is detected
+- When onboarding new team members
+- To enforce architectural decisions before production
+
+## Evidence sources
+
+Scan for: import/dependency patterns, layer violations (e.g. API calling DB directly), abstraction violations, circular dependencies, forbidden dependencies.
+
+## Outputs
+
+Adds section to:
+
+- `docs/architecture/02-quality-attributes.md` — "Architecture Rules"
+- Or `docs/architecture/00-system-architecture.md`
+- Optionally: architecture test scaffolding
+
+## Dependency rules format
+
+```markdown
+## Architecture Rules
+
+### Allowed Dependencies
+- ✅ API → Service → Repository → Database
+- ✅ Service → Abstraction (interface)
+- ✅ Frontend → API (via client abstraction)
+
+### Forbidden Dependencies
+- ❌ API → Repository (must go through Service)
+- ❌ Service → Concrete (must use abstraction)
+- ❌ Domain → Infrastructure
+```
+
+## Layer boundaries
+
+Define layers and rules:
+
+- **Presentation** — MAY depend on Application; MUST NOT depend on Data
+- **Application** — MAY depend on Domain, Data (through abstractions only); MUST NOT depend on Presentation
+- **Data** — MAY depend on Domain; MUST NOT depend on Application or Presentation
+
+## Architecture test approach
+
+Propose verification (Python: `import-linter`, AST, pytest; TypeScript: `madge`, `dependency-cruiser`). Example:
+
+```python
+def test_api_does_not_import_repositories():
+    """API routes must not directly import repositories."""
+    violations = check_imports(api_modules, repo_modules)
+    assert len(violations) == 0
+```
+
+## Enforcement levels
+
+1. Documentation only — manual review
+2. Linter/static analysis — IDE and CI
+3. Architecture tests — blocks merges on violations
+
+## Update rules
+
+- Document actual violations found; cite evidence
+- Mark rules as "Enforced" vs "Aspirational"
+
+## Integration
+
+- Parent: [architecture](../SKILL.md) orchestrator.
+- Complements [architecture-decisions](../architecture-decisions/SKILL.md) for constraint documentation.

--- a/skills/architecture/architecture-decisions/SKILL.md
+++ b/skills/architecture/architecture-decisions/SKILL.md
@@ -81,7 +81,12 @@ Update `docs/architecture/09-decisions.md`:
 **Rules:**
 - ADRs are immutable once accepted — supersede with a new ADR, don't edit
 - Numbering: sequential `001-title.md`; check existing ADRs for next number
-- After creating: update affected component/abstraction docs to reference this ADR; add to `00-system-architecture.md` ADR index
+- After creating: update affected component/abstraction docs; add to `00-system-architecture.md` ADR index
+- Status values: Proposed | Accepted | Deprecated | Superseded
+
+## Migration programme (AMIs)
+
+For incremental refactors, maintain `docs/architecture/98-migration-plan.md` (planned/in-progress) and `97-migration-log.md` (completed). Each AMI: intent, scope, seams first, compatibility strategy (feature flag/adapter/parallel run), tests, verification, rollback plan. Prioritise by risk, dependency order, business value. See [architecture-risks-debt](../architecture-risks-debt/SKILL.md) for tech debt.
 
 ## Integration
 

--- a/skills/architecture/architecture-document-existing/SKILL.md
+++ b/skills/architecture/architecture-document-existing/SKILL.md
@@ -65,16 +65,22 @@ Create or update:
 | `src/frontend/` | [inferred from structure] | High/Medium/Low |
 ```
 
-Open issues format:
+Open issues format (use in `99-open-issues.md`):
 ```markdown
 ## [Issue Title]
 **Context**: What we know
 **Question**: What we need to decide
-**Options**: 1. A (pros/cons)  2. B (pros/cons)
+**Options**:
+1. Option A (pros/cons)
+2. Option B (pros/cons)
+3. Option C (pros/cons)
+**Recommendation**: [if any]
 **Decision**: [when resolved, link to ADR]
 ```
 
-**Initial baseline guidance:** Produce a "good enough" baseline — 1–2 paragraphs per component initially. Focus on getting structure right; details can evolve. An incomplete baseline today is more useful than a perfect baseline never written.
+**Response structure:** Return results as: (1) Inferred project purpose (Facts/Assumptions/Unknowns), (2) Component inventory with delegation list, (3) Abstraction inventory, (4) Current baseline summary, (5) Drift/risks and Open Issue links, (6) Generated/updated docs, (7) Migration programme summary if needed, (8) Open issues summary.
+
+**Initial baseline guidance:** Produce a "good enough" baseline — 1–2 paragraphs per component initially. Focus on getting structure right; details can evolve. Delegate to [architecture-building-blocks](../architecture-building-blocks/SKILL.md) for component/abstraction details, [architecture-runtime](../architecture-runtime/SKILL.md) for flows, [architecture-decisions](../architecture-decisions/SKILL.md) for ADRs.
 
 ## Integration
 

--- a/skills/architecture/architecture-glossary/SKILL.md
+++ b/skills/architecture/architecture-glossary/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: architecture-glossary
+description: Maintains glossary of business and technical terms (arc42 §12). Use when defining domain vocabulary or resolving terminology ambiguity.
+---
+
+# Architecture Glossary
+
+Maintains ubiquitous language — shared vocabulary across architecture, code, and UI. Aligns with arc42 §12 (glossary). DDD concept: same terms everywhere to avoid confusion.
+
+## When to use
+
+- Defining new domain concepts or clarifying existing ones
+- Resolving ambiguity (e.g. "Transcription" vs "Speech-to-Text")
+- Onboarding — new team members learning terminology
+- Architecture reviews — ensuring consistent vocabulary
+- Refactoring — when considering renames
+
+## Output
+
+`docs/architecture/07-ubiquitous-language.md`
+
+## Definition entry format
+
+```markdown
+### Term Name
+**Category:** Domain Concept / Technical Concept / UI Concept
+**Definition:** Clear, concise definition.
+**Synonyms:** Alternative terms (list all)
+**Related Terms:** Related but distinct
+**Usage Examples:** Code, documentation, UI
+**Anti-patterns:** ❌ Don't call it X (confusing)
+**References:** [Component](../components/...), [ADR](../adr/...)
+```
+
+## Synonym groups
+
+When multiple terms refer to same concept:
+
+```markdown
+### Speech-to-Text / Transcription / STT
+**Preferred Term:** Speech-to-Text
+**Acceptable Synonyms:** Transcription (code), STT (deprecated)
+**Definition:** Converting spoken audio into written text.
+**Usage Guidelines:** Doc: "Speech-to-Text"; Code: `transcribe()` acceptable
+```
+
+## Operations
+
+- **Look up**: Read glossary, search term, display definition
+- **Define**: Check if exists; create entry; cross-reference ADRs, components
+- **List**: Extract headings, display alphabetically
+- **Validate**: Search codebase for inconsistent usage; report violations
+
+## Update rules
+
+- Evidence-based: include code examples
+- Living document: update during refactoring
+- Document synonyms when multiple terms exist
+
+## Integration
+
+- [architecture-decisions](../architecture-decisions/SKILL.md) for terminology ADRs
+- [architecture-building-blocks](../architecture-building-blocks/SKILL.md) for component terms

--- a/skills/architecture/architecture-runtime/SKILL.md
+++ b/skills/architecture/architecture-runtime/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: architecture-runtime
+description: Documents runtime behaviour: technical execution paths, component interactions, sequences (arc42 §6). Use when documenting flows or tracing execution.
+---
+
+# Architecture Runtime
+
+Documents technical execution paths through components and services. Aligns with arc42 §6 (runtime view). Contrast with **user flows** (UX journey) — see [design-consult](../../design/design-consult/SKILL.md) for user flow documentation.
+
+## When to use
+
+- Documenting critical execution paths
+- When new features add significant flows
+- Debugging complex interactions
+
+## Outputs
+
+- `docs/architecture/03-runtime-flows.md` — append/update scenario
+- `docs/architecture/diagrams/sequences.mmd` — sequence diagram
+
+## Flow scenario format
+
+For each scenario in `03-runtime-flows.md`:
+
+1. **Trigger** — what initiates; entry point; preconditions
+2. **Step-by-step** — technical sequence (HTTP → Controller → Service → DB)
+3. **Components involved** — links to component docs
+4. **Data touched** — tables, cache, external APIs
+5. **Error handling** — what can fail; retries; fallbacks
+6. **Observability** — logs, metrics, traces
+
+## Selection criteria
+
+Prioritise: MVP smoke test path; most frequently executed; business-critical; complex (multi-component); error-prone.
+
+## Sequence diagram
+
+Use Mermaid `sequenceDiagram` with participants, messages, returns, error paths.
+
+## Update rules
+
+- Document actual code paths; cite evidence
+- Link to component docs
+- Show success and error paths
+
+## Integration
+
+- Parent: [architecture](../SKILL.md).
+- Complements [architecture-building-blocks](../architecture-building-blocks/SKILL.md) for component details.

--- a/skills/design/design-consult/SKILL.md
+++ b/skills/design/design-consult/SKILL.md
@@ -46,6 +46,10 @@ Maps where new code fits within existing components, interfaces, and data flows.
 - [Convention from existing code]
 ```
 
+## User flow documentation
+
+When documenting *user journeys* (UX perspective: clicks, screens, interactions), create `docs/architecture/04-user-flows.md`. Document: user goal; step-by-step journey; screens/routes; frontend components; validation; error states; link to [architecture-runtime](../../architecture/architecture-runtime/SKILL.md) for technical flows. User flow = what user sees/does; runtime flow = technical execution path.
+
 ## Integration
 
 - Follows [architecture-consult](../../architecture/architecture-consult/SKILL.md).


### PR DESCRIPTION
Closes #28

## Summary
- Merge sir-read-a-lot arch skills into pkuppens/skills/architecture
- **New skills**: architecture-runtime, architecture-crosscutting, architecture-glossary
- **Merged into existing**: architecture-document-existing, architecture-building-blocks, architecture-decisions, design-consult
- Update COOPERATION.md, SKILL_TREE.md, audit-results.md

## Acceptance Criteria
- [x] All unique content from sir-read-a-lot arch skills present in pkuppens
- [x] Each merged SKILL.md under 300 lines
- [x] SKILL_TREE architecture section reflects final state

Made with [Cursor](https://cursor.com)