### PR TITLE
#42: V-model skills overlay (traceability + brownfield retrofit)

### DIFF
--- a/skills/CLAUDE.md
+++ b/skills/CLAUDE.md
@@ -11,7 +11,8 @@ This directory contains unified AI coding skills for Cursor, Claude, and Codex. 
 - Each skill lives in its own directory with `SKILL.md`
 - Skill tree overview: [SKILL_TREE.md](SKILL_TREE.md)
 - Cooperation patterns: [COOPERATION.md](COOPERATION.md)
-- Meta-skills (e.g. skill-creation) in `_meta/`
+- Meta-skills (e.g. skill-creation, human-ai-execution) in `_meta/`
+- Optional V-model overlay: [v-model/SKILL.md](v-model/SKILL.md)
 
 ## Creating or editing skills
 

--- a/skills/COOPERATION.md
+++ b/skills/COOPERATION.md
@@ -23,6 +23,32 @@ issue-acceptance-criteria → validation-draft → test-write → implementation
 
 Validation and tests are drafted before implementation.
 
+### V-model flow (optional overlay)
+
+When using [v-model](v-model/SKILL.md), each **left-arm** artefact has a corresponding **right-arm** verification concern. In **Agile**, run a **mini-V** per issue (slice), not only once per release. **Shift-left:** the right arm may start before the left arm is “finished” for that slice (same as TDD). **Brownfield:** use [v-model-retrofit](v-model/v-model-retrofit/SKILL.md) for explicit backfill or touch-driven alignment.
+
+```mermaid
+flowchart TB
+  subgraph leftArm [Left_arm_artefacts]
+    R[requirements_2x]
+    A[architecture_3x]
+    D[design_4x]
+    I[implementation_7x]
+  end
+  subgraph rightArm [Right_arm_verification]
+    VA[acceptance_validation_8x]
+    VS[system_integration_8x_9x]
+    VC[component_contract_8x_9x]
+    VU[unit_tests_9x]
+  end
+  R --> VA
+  A --> VS
+  D --> VC
+  I --> VU
+```
+
+**Retrofitting + V:** [Architecture](architecture/SKILL.md) **Retrofitting** mode establishes *what is*. `v-model-retrofit` links *what is* to *how we verify it* (tests, checks, evidence).
+
 ## Parallel (independent) skills
 
 These can run in any order or in parallel when context is ready:
@@ -104,6 +130,8 @@ Store results in `tmp/skills/benchmark/<skill-name>/`.
 | Monitoring anomaly | operations-incident |
 | Quarterly / pre-audit | operations-audit |
 | New or revised skill | skill-benchmark |
+| Traceability / V-model / compliance-style pairing | [v-model](v-model/SKILL.md); brownfield: [v-model-retrofit](v-model/v-model-retrofit/SKILL.md) |
+| Normal code change on existing codebase (optional) | Consider **touch-driven** `v-model-retrofit`: extend verification only for touched boundaries unless user widens scope |
 
 ## Skill references
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,7 +6,7 @@ Shared skills for Cursor, Claude, and Codex. Committed to this repo; referenced 
 
 Skills are markdown files (`SKILL.md`) in skill-specific directories. Each skill has a `name` and `description` in YAML frontmatter; IDEs discover skills automatically when the directory is linked.
 
-Full skill tree: [SKILL_TREE.md](SKILL_TREE.md). How skills compose: [COOPERATION.md](COOPERATION.md).
+Full skill tree: [SKILL_TREE.md](SKILL_TREE.md). How skills compose: [COOPERATION.md](COOPERATION.md). Optional **V-model** traceability overlay: [v-model/SKILL.md](v-model/SKILL.md).
 
 ## IDE Setup
 
@@ -57,8 +57,9 @@ skills/
 ├── CLAUDE.md           # Agent instructions
 ├── SKILL_TREE.md
 ├── _meta/              # Meta-skills
-│   └── skill-creation/
-│       └── SKILL.md
+│   ├── skill-creation/
+│   │   └── SKILL.md
+│   └── human-ai-execution.md
 ├── ideation/
 ├── requirements/
 ├── architecture/
@@ -73,5 +74,6 @@ skills/
 ├── deployment/
 ├── operations/
 ├── maintenance/
-└── governance/
+├── governance/
+└── v-model/            # V-model overlay (orchestrator + 6 sub-skills)
 ```

--- a/skills/SKILL_TREE.md
+++ b/skills/SKILL_TREE.md
@@ -15,6 +15,7 @@ Personal skills for AI-assisted coding, aligned with arc42 and the full software
 | **Waterfall** | Fixed scope, formal phases, sign-off gates | Sequential: requirements → architecture → design → implementation → validation. Fewer parallel branches. |
 | **Agile** | Iterative, incremental, changing scope | Short cycles; issue-workflow per sprint; backlog grooming; retrospectives. |
 | **TDD** | Test-first, red-green-refactor | validation-draft and test-write before implementation-construction; validation-detail after. |
+| **V-model** | Traceability between artefacts and verification; regulated or high-assurance contexts; teaching pairing | Pair left-side work (requirements → implementation, skills **2–7**) with right-side verification (**8–10**). Use [v-model](v-model/SKILL.md). **Brownfield:** [v-model-retrofit](v-model/v-model-retrofit/SKILL.md). Composes with **Agile** (mini-V per issue) and **TDD**. |
 
 ---
 
@@ -349,6 +350,33 @@ Maintains audit trail: decisions, changes, evidence.
 
 ---
 
+## Process overlay: V-model
+
+Skills in this section are **optional overlays**: they describe how to pair lifecycle artefacts with verification. They do **not** replace or renumber skills **0–15**.
+
+### v-model
+Maps classic V-model stages to this tree; supports **incremental / Agile V** (vertical slices, mini-V per issue) and **brownfield** adoption. Entry point for pairing sub-skills.
+
+#### v-model-mapping
+Maps classic V-model arms to [requirements](requirements/SKILL.md) / [architecture](architecture/SKILL.md) / [design](design/SKILL.md) / [implementation](implementation/SKILL.md) and to [validation](validation/SKILL.md) / [test](test/SKILL.md) / [quality-gate](quality-gate/SKILL.md). Explains many-to-many alignment with arc42.
+
+#### v-model-requirements-acceptance
+Pairs requirements (2.x) and [issue-acceptance-criteria](issue-workflow/issue-acceptance-criteria/SKILL.md) with acceptance-level validation (8.x).
+
+#### v-model-architecture-integration
+Pairs architecture (3.x) with integration- and structure-level verification (8.x, 9.x).
+
+#### v-model-design-verification
+Pairs detailed design (4.x) and [design-consult](design/design-consult/SKILL.md) with component or contract-level checks (8.2, 9.x).
+
+#### v-model-implementation-unit
+Pairs [implementation-construction](implementation/implementation-construction/SKILL.md) (7.x) with unit-level tests (9.1).
+
+#### v-model-retrofit
+**Brownfield:** explicit backfill issues vs **touch-driven** updates during normal changes. Links “what exists” (e.g. architecture Retrofitting mode) to “how we verify it.”
+
+---
+
 ## Language & Framework Skills
 
 ### find-skills
@@ -392,8 +420,9 @@ Explains git worktrees and Claude Code usage; guides removal and cleanup when a 
 | 13 | operations | Production, monitoring, audit | 13.1–13.3 |
 | 14 | maintenance | Bug report, cleanup, debt | 14.1–14.3 |
 | 15 | governance | Progress, post-mortem, audit trail | 15.1–15.3 |
+| — | v-model *(overlay)* | Traceability pairing (optional) | mapping, requirements-acceptance, architecture-integration, design-verification, implementation-unit, retrofit |
 
-**Total:** 1 meta-skill + 16 lifecycle skills, 60+ sub-skills. Nesting: up to 4–5 levels where needed (e.g. 5.4.1, 5.4.2).
+**Total:** 1 meta-skill + 16 lifecycle skills + **V-model overlay** (6 sub-skills), 60+ sub-skills elsewhere. Nesting: up to 4–5 levels where needed (e.g. 5.4.1, 5.4.2).
 
 ## Implementation Status
 
@@ -416,4 +445,6 @@ Explains git worktrees and Claude Code usage; guides removal and cleanup when a 
 | maintenance-cleanup (14.2) | ✅ implemented |
 | plan (orchestrator: branch strategy, implementation-workflow through PR/CI) | ✅ implemented |
 | plan-branch-strategy (6.3) | ✅ implemented |
-| ideation, requirements, design (4.2–4.4), plan 6.1–6.2, test, validation (8.2–8.3), maintenance (14.1, 14.3), governance | 🔲 stubs / not yet implemented |
+| ideation, requirements **sub-skills** (2.1–2.6), design (4.2–4.4), plan 6.1–6.2, test **sub-skills** (9.1–9.3 files), validation (8.2–8.3), maintenance (14.1, 14.3), governance | 🔲 stubs / not yet implemented |
+| requirements / design / implementation / validation / test **orchestrator** SKILL.md (#42) | ✅ minimal stubs (nav + V-model links) |
+| v-model overlay (#42) | ✅ implemented |

--- a/skills/_meta/human-ai-execution.md
+++ b/skills/_meta/human-ai-execution.md
@@ -1,0 +1,29 @@
+# Human vs AI execution (issues and skills)
+
+Use this note when scoping GitHub issues and when agents follow skills that affect **judgment**, **sign-off**, or **compliance**.
+
+## GitHub labels (pkuppens repo)
+
+| Label | When to use |
+|-------|-------------|
+| `execution:ai-ok` | Safe for an agent to execute end-to-end (e.g. drafting Markdown, scaffolding, link checks). Human merge review is still normal. |
+| `execution:human-review` | Agent may draft; a human must approve content, merge, or external sign-off. |
+| `execution:human-required` | Human must perform the step (stakeholder decision, regulatory interpretation, production change approval). |
+| `retrofit:explicit` | Dedicated backfill / close-the-V scope for a module or system slice. |
+| `retrofit:incremental` | Only extend traceability for code **touched** by this issue unless scope is widened. |
+
+## Issue body template (optional)
+
+Add an **Execution** block so ownership stays with the issue, not only on the board:
+
+```markdown
+## Execution
+- [ ] (ai-ok) …
+- [ ] (human-review) …
+- [ ] (human-required) …
+```
+
+## Relation to skills
+
+- [v-model](../v-model/SKILL.md) and [v-model-retrofit](../v-model/v-model-retrofit/SKILL.md) often produce **human-review** artefacts (tests and docs that encode intent).
+- [issue-workflow](../issue-workflow/SKILL.md) should still define clear acceptance criteria; humans remain accountable for what “done” means in regulated contexts.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: design
+description: Defines detailed design components, interfaces, and data flows. Use when working in lifecycle area 4.x per SKILL_TREE. Orchestrates with design-consult and future 4.2–4.4 skills.
+---
+
+# Design (orchestrator)
+
+Canonical index: [SKILL_TREE.md](../SKILL_TREE.md) §4.
+
+Implemented: [design-consult](design-consult/SKILL.md). For V pairing, see [v-model-design-verification](../v-model/v-model-design-verification/SKILL.md).

--- a/skills/implementation/SKILL.md
+++ b/skills/implementation/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: implementation
+description: Code construction, refactor, and deletion per SKILL_TREE §7. Use when implementing or changing behaviour; delegates to 7.1–7.3.
+---
+
+# Implementation (orchestrator)
+
+Canonical index: [SKILL_TREE.md](../SKILL_TREE.md) §7.
+
+Implemented: [implementation-construction](implementation-construction/SKILL.md). For V pairing with unit tests, see [v-model-implementation-unit](../v-model/v-model-implementation-unit/SKILL.md).

--- a/skills/issue-workflow/SKILL.md
+++ b/skills/issue-workflow/SKILL.md
@@ -64,3 +64,7 @@ Labels: size:M, type:task — Milestone: (none) — Parent: #N
 ## Integration
 
 Uses `gh` CLI: `gh issue list`, `gh issue view`, `gh issue create`. Ensure `gh auth login` if needed.
+
+### Optional: V-model traceability
+
+For issues in regulated, high-assurance, or “must prove verification” contexts, after acceptance criteria are drafted consider [v-model](../v-model/SKILL.md) so each AC can be tied to validation/tests. For **brownfield** work, see [v-model-retrofit](../v-model/v-model-retrofit/SKILL.md). Execution ownership: [_meta/human-ai-execution.md](../_meta/human-ai-execution.md).

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -37,6 +37,10 @@ Every implementation plan **must** include these steps:
 
 **Summary:** Validate first; work from a feature branch; complete through PR; do not stop until PR is open and CI has validated (or N/A).
 
+### Optional: V-model and brownfield
+
+When the project or issue calls for **traceability** (pairing specs/design with tests), follow [v-model](../v-model/SKILL.md). On an **existing codebase**, default to **touch-driven** [v-model-retrofit](../v-model/v-model-retrofit/SKILL.md): strengthen tests and minimal docs only for the **surfaces changed** in this issue unless the user or issue explicitly requests a wider retrofit (`retrofit:explicit`).
+
 ## Sub-skills
 
 | Sub-skill | Use when |

--- a/skills/requirements/SKILL.md
+++ b/skills/requirements/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: requirements
+description: Captures, refines, and validates requirements; aligns with goals and constraints. Use when working in lifecycle area 2.x per SKILL_TREE. Sub-skills 2.1–2.6 are stubs until implemented.
+---
+
+# Requirements (orchestrator)
+
+Canonical index: [SKILL_TREE.md](../SKILL_TREE.md) §2. Sub-skills (2.1–2.6) are listed there; dedicated `SKILL.md` files per sub-skill may be added later.
+
+When pairing with verification, see [v-model-requirements-acceptance](../v-model/v-model-requirements-acceptance/SKILL.md).

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: test
+description: Writes and runs tests; increases coverage per SKILL_TREE §9. Sub-skills 9.1–9.3 are stubs until fully implemented as separate workflows.
+---
+
+# Test (orchestrator)
+
+Canonical index: [SKILL_TREE.md](../SKILL_TREE.md) §9.
+
+Sub-skills **9.1–9.3** (test-write, test-run, test-coverage) are listed in [SKILL_TREE.md](../SKILL_TREE.md); dedicated files may be added later. Follow repo test conventions. V-model: [v-model-implementation-unit](../v-model/v-model-implementation-unit/SKILL.md).

--- a/skills/v-model/SKILL.md
+++ b/skills/v-model/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: v-model
+description: Maps V-model traceability to the skill tree (requirements through tests). Use when pairing left-arm artefacts with right-arm verification, Agile mini-V per issue, brownfield retrofit, or compliance-style evidence. Third person.
+---
+
+# V-model (process overlay)
+
+Optional overlay on skills **2–15**: pair **what we specify and build** with **how we verify** it. Does **not** replace the numbered lifecycle; it routes you to the right sub-skills.
+
+## When to use
+
+- Need traceability from acceptance criteria or requirements down to tests (or the reverse).
+- Regulated, audited, or high-assurance context where “对应关系” between artefacts and verification matters.
+- Teaching or refining workflow in **Agile**: each backlog item can run a **mini-V** (vertical slice).
+- **Brownfield:** code exists without a closed V; see [v-model-retrofit](v-model-retrofit/SKILL.md).
+
+## When not to default to greenfield
+
+If the codebase already exists, **do not** assume the user wants full upfront requirements for the whole system. Prefer **Retrofitting** architecture mode plus **touch-driven** retrofit unless an issue says otherwise.
+
+## Sub-skills (use in order as needed)
+
+| Sub-skill | Role |
+|-----------|------|
+| [v-model-mapping](v-model-mapping/SKILL.md) | Classic V ↔ SKILL_TREE; many-to-many with arc42 |
+| [v-model-requirements-acceptance](v-model-requirements-acceptance/SKILL.md) | 2.x + AC ↔ acceptance validation |
+| [v-model-architecture-integration](v-model-architecture-integration/SKILL.md) | 3.x ↔ integration / structural verification |
+| [v-model-design-verification](v-model-design-verification/SKILL.md) | 4.x ↔ component / contract verification |
+| [v-model-implementation-unit](v-model-implementation-unit/SKILL.md) | 7.x ↔ unit tests |
+| [v-model-retrofit](v-model-retrofit/SKILL.md) | Explicit backfill vs incremental on touched code |
+
+## Agile and shift-left
+
+- **Incremental V:** one issue = one slice; complete the mapping for that slice.
+- **Shift-left:** [validation-draft](../validation/validation-draft/SKILL.md) and tests may precede stable specs for that slice (same idea as TDD in [COOPERATION.md](../COOPERATION.md)).
+- **CI:** [quality-gate](../quality-gate/SKILL.md) automates parts of the lower right arm continuously.
+
+## Human vs AI
+
+See [_meta/human-ai-execution.md](../_meta/human-ai-execution.md). Interpreting “intent” of legacy code as requirements is usually **human-review** or **human-required**.
+
+## Integration
+
+- Issues: [issue-workflow](../issue-workflow/SKILL.md), [issue-acceptance-criteria](../issue-workflow/issue-acceptance-criteria/SKILL.md).
+- Planning: [plan](../plan/SKILL.md).
+- Composition: [COOPERATION.md](../COOPERATION.md) V-model section.

--- a/skills/v-model/SKILL.md
+++ b/skills/v-model/SKILL.md
@@ -10,7 +10,7 @@ Optional overlay on skills **2–15**: pair **what we specify and build** with *
 ## When to use
 
 - Need traceability from acceptance criteria or requirements down to tests (or the reverse).
-- Regulated, audited, or high-assurance context where “对应关系” between artefacts and verification matters.
+- Regulated, audited, or high-assurance context where **traceability** between artefacts and verification matters.
 - Teaching or refining workflow in **Agile**: each backlog item can run a **mini-V** (vertical slice).
 - **Brownfield:** code exists without a closed V; see [v-model-retrofit](v-model-retrofit/SKILL.md).
 

--- a/skills/v-model/v-model-architecture-integration/SKILL.md
+++ b/skills/v-model/v-model-architecture-integration/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: v-model-architecture-integration
+description: Pairs architecture artefacts with integration and structural verification. Use when boundaries, deployment, or runtime scenarios must be proven in tests. Third person.
+---
+
+# V-model: architecture ↔ integration
+
+Links **left:** [architecture](../../architecture/SKILL.md) (**3.x**) — building blocks, runtime, deployment, decisions — with **right:** integration-style verification (**8.x**, **9.x**).
+
+## When to use
+
+- New services, APIs between components, or deployment topology changes.
+- Refactors that move boundaries between modules or processes.
+
+## Instructions
+
+1. Consult [architecture-consult](../../architecture/architecture-consult/SKILL.md) or document the target state (**3.x**).
+2. Identify **integration surfaces** (HTTP/gRPC/queue/DB contracts, process boundaries).
+3. Define tests that fail if those boundaries regress: contract tests, narrow integration tests, or smoke paths; align with [validation-detail](../../validation/validation-detail/SKILL.md) where scenarios are known.
+4. Record risky decisions in [architecture-decisions](../../architecture/architecture-decisions/SKILL.md) when verification encodes a specific option.
+
+## Relation to arc42
+
+Runtime (**3.4**) and deployment (**3.5**) views often drive **which** integration tests matter most.
+
+## Related
+
+- [v-model-mapping](../v-model-mapping/SKILL.md)
+- [v-model-retrofit](../v-model-retrofit/SKILL.md) for undocumented systems

--- a/skills/v-model/v-model-design-verification/SKILL.md
+++ b/skills/v-model/v-model-design-verification/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: v-model-design-verification
+description: Pairs detailed design with component and contract-level verification. Use when APIs, schemas, or module contracts need proving tests. Third person.
+---
+
+# V-model: design ↔ verification
+
+Links **left:** [design](../../design/SKILL.md) (**4.x**) and [design-consult](../../design/design-consult/SKILL.md) with **right:** component-level and contract-level checks (**8.2**, **9.x**).
+
+## When to use
+
+- APIs, data schemas, or internal interfaces are stable enough to test against.
+- You need tests that pin behaviour at module boundaries without full system cost.
+
+## Instructions
+
+1. Name the **contract**: inputs, outputs, errors, invariants (from **4.3**, **4.4** when present).
+2. Draft checks via [validation-draft](../../validation/validation-draft/SKILL.md); tighten with [validation-detail](../../validation/validation-detail/SKILL.md) after implementation exists.
+3. Prefer [test-write](../../test/test-write/SKILL.md) for automated contracts; document any manual-only checks in the issue or runbook.
+
+## Pitfalls
+
+- **Over-mocking:** integration value disappears if everything is mocked — pick the right layer (see [v-model-architecture-integration](../v-model-architecture-integration/SKILL.md)).
+
+## Related
+
+- [v-model-mapping](../v-model-mapping/SKILL.md)
+- [implementation-construction](../../implementation/implementation-construction/SKILL.md)

--- a/skills/v-model/v-model-implementation-unit/SKILL.md
+++ b/skills/v-model/v-model-implementation-unit/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: v-model-implementation-unit
+description: Pairs implementation work with unit-level tests. Use when closing the bottom of the V for modules and pure logic. Third person.
+---
+
+# V-model: implementation ↔ unit tests
+
+Links **left:** [implementation](../../implementation/SKILL.md) (**7.x**) — especially [implementation-construction](../../implementation/implementation-construction/SKILL.md) — with **right:** fast, isolated tests (**9.1**).
+
+## When to use
+
+- New or changed functions/classes with deterministic behaviour.
+- Bug fixes where a unit test should lock the fix.
+
+## Instructions
+
+1. From the issue AC, derive cases (happy, edge, failure); use [validation-draft](../../validation/validation-draft/SKILL.md) if helpful.
+2. Add or update tests with [test-write](../../test/test-write/SKILL.md); run [test-run](../../test/test-run/SKILL.md) or project test command.
+3. Run [quality-gate](../../quality-gate/SKILL.md) before commit.
+
+## TDD variant
+
+If the team uses test-first ordering, write **9.1** before finishing **7.1** for that change set (see [COOPERATION.md](../../COOPERATION.md) TDD flow).
+
+## Related
+
+- [v-model-design-verification](../v-model-design-verification/SKILL.md) for boundary-heavy code
+- [v-model-retrofit](../v-model-retrofit/SKILL.md) when legacy code lacks tests

--- a/skills/v-model/v-model-mapping/SKILL.md
+++ b/skills/v-model/v-model-mapping/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: v-model-mapping
+description: Maps classic V-model stages to pkuppens SKILL_TREE skills 2–10. Use when explaining or applying V traceability alongside arc42 and Agile slices. Third person.
+---
+
+# V-model mapping
+
+Relates **classic V-model** ideas to this repository’s skills. arc42 (**3.x**) is richer than a single classic V box; treat mapping as **many-to-many**, not a rigid 1:1.
+
+## Classic left arm (decomposition) ↔ skills
+
+| Classic stage (left) | Primary skills | Notes |
+|---------------------|----------------|-------|
+| Requirements / analysis | [requirements](../../requirements/SKILL.md) (**2.x**), [issue-acceptance-criteria](../../issue-workflow/issue-acceptance-criteria/SKILL.md) | AC often acts as the testable requirement for a slice. |
+| High-level / system design | [architecture-solution-strategy](../../architecture/architecture-solution-strategy/SKILL.md), [architecture-building-blocks](../../architecture/architecture-building-blocks/SKILL.md), **3.x** | Spans several arc42 sections. |
+| Detailed design | [design](../../design/SKILL.md) (**4.x**), [design-consult](../../design/design-consult/SKILL.md) | APIs, components, data shapes. |
+| Implementation | [implementation](../../implementation/SKILL.md) (**7.x**) | Code construction and refactors. |
+
+## Classic right arm (integration & verification) ↔ skills
+
+| Classic stage (right) | Primary skills | Notes |
+|----------------------|----------------|-------|
+| Unit / component test | [test-write](../../test/test-write/SKILL.md) (**9.1**), [validation-detail](../../validation/validation-detail/SKILL.md) | Closest to module-level V leg. |
+| Integration test | **9.x**, **8.x**, [architecture-runtime](../../architecture/architecture-runtime/SKILL.md) (behaviour to assert) | Scenarios drive what to integrate-test. |
+| System test | **8.3** [validation-run](../../validation/validation-run/SKILL.md), **9.2** | Full stack or system slice. |
+| Acceptance | **8.x**, issue AC | Stakeholder-facing evidence; may be manual or automated. |
+
+## Quality automation
+
+[quality-gate](../../quality-gate/SKILL.md) (**10.x**) supports the right arm continuously (lint, type, security) but does not replace domain tests.
+
+## Next steps
+
+- For pairing guidance at each level, use the other **v-model-*** sub-skills under [v-model](../SKILL.md).
+- For existing codebases, use [v-model-retrofit](../v-model-retrofit/SKILL.md).

--- a/skills/v-model/v-model-requirements-acceptance/SKILL.md
+++ b/skills/v-model/v-model-requirements-acceptance/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: v-model-requirements-acceptance
+description: Pairs requirements and issue acceptance criteria with acceptance-level validation. Use when closing the top of the V for a feature or release slice. Third person.
+---
+
+# V-model: requirements ↔ acceptance
+
+Links **left:** [requirements](../../requirements/SKILL.md) (**2.x**) and well-formed [issue-acceptance-criteria](../../issue-workflow/issue-acceptance-criteria/SKILL.md) with **right:** acceptance-oriented validation (**8.x**).
+
+## When to use
+
+- Defining or refining an issue so each AC maps to observable evidence.
+- Preparing stakeholder demo, UAT, or audit evidence for “what we said we would deliver.”
+
+## Instructions
+
+1. Ensure acceptance criteria are **testable** (copy-pastable steps where possible).
+2. For each AC, name the **validation** method: automated check, scripted test, manual checklist, or monitored metric.
+3. Use [validation-draft](../../validation/validation-draft/SKILL.md) to derive scenarios; refine with [validation-detail](../../validation/validation-detail/SKILL.md) once behaviour is known.
+4. If requirements docs exist (goals, constraints, scope from **2.x**), add explicit **forward references** from AC to those clauses where helpful.
+
+## Pitfalls
+
+- **Duplicate prose:** keep one canonical statement of intent; link instead of copying long specs into both issue and docs.
+- **Mushy AC:** “works well” → replace with measurable or binary checks.
+
+## Related
+
+- [v-model-mapping](../v-model-mapping/SKILL.md)
+- [issue-workflow](../../issue-workflow/SKILL.md)

--- a/skills/v-model/v-model-retrofit/SKILL.md
+++ b/skills/v-model/v-model-retrofit/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: v-model-retrofit
+description: Applies V-model traceability to brownfield codebases via explicit retrofit issues or touch-driven updates during normal work. Use when the system was built without a closed V. Third person.
+---
+
+# V-model retrofit (brownfield)
+
+Most code never had a perfect left/right V. This skill defines **two modes** so agents do not imply a big-bang rewrite.
+
+## Mode A — Explicit retrofit
+
+**Trigger:** User request or a dedicated issue (label `retrofit:explicit`).
+
+**Goal:** Backfill traceability for a named scope (module, bounded context, feature area).
+
+**Steps:**
+
+1. Understand **as-built** state: [architecture-document-existing](../../architecture/architecture-document-existing/SKILL.md), [architecture-consult](../../architecture/architecture-consult/SKILL.md) as needed.
+2. Scope with [issue-work-down](../../issue-workflow/issue-work-down/SKILL.md); define **acceptance criteria for the retrofit** (e.g. “ADRs for boundaries X/Y”, “integration tests for API Z”).
+3. Apply pairing sub-skills ([v-model](../SKILL.md)) **inside that scope only**; prefer **small PRs**.
+4. When inferring *intent* from legacy behaviour, treat conclusions as **human-review** or **human-required** — do not silently elevate guesses to requirements. See [_meta/human-ai-execution.md](../../_meta/human-ai-execution.md).
+
+## Mode B — Touch-driven (incremental)
+
+**Trigger:** Ordinary bugfix or feature work; label `retrofit:incremental` optional.
+
+**Goal:** Strengthen the V only for **surfaces touched** by this change unless the user widens scope.
+
+**Steps:**
+
+1. Map the change to the issue **acceptance criteria** ([issue-acceptance-criteria](../../issue-workflow/issue-acceptance-criteria/SKILL.md)).
+2. Add or adjust **tests** proving the AC for this change ([validation-draft](../../validation/validation-draft/SKILL.md), [test-write](../../test/test-write/SKILL.md)).
+3. If the change invalidates an undocumented assumption, add the **smallest** helpful ADR or architecture note ([architecture-decisions](../../architecture/architecture-decisions/SKILL.md) or consult) — **do not** document the entire system because one helper changed.
+4. If the touch reveals a **large gap**, comment on the issue or open a follow-up; do not silently expand scope.
+
+## Relation to architecture Retrofitting
+
+[Architecture](../../architecture/SKILL.md) **Retrofitting** mode answers **what is**. `v-model-retrofit` adds **how we verify it** and links evidence to issues and artefacts.
+
+## Related
+
+- [plan](../../plan/SKILL.md) — optional V-model note during implementation planning
+- [v-model-mapping](../v-model-mapping/SKILL.md)

--- a/skills/validation/SKILL.md
+++ b/skills/validation/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: validation
+description: Drafts and executes validation steps; ensures acceptance criteria are met. Use when working in lifecycle area 8.x per SKILL_TREE.
+---
+
+# Validation (orchestrator)
+
+Canonical index: [SKILL_TREE.md](../SKILL_TREE.md) §8.
+
+Implemented: [validation-draft](validation-draft/SKILL.md), [skill-benchmark](skill-benchmark/SKILL.md). V-model links: [v-model-mapping](../v-model/v-model-mapping/SKILL.md).


### PR DESCRIPTION
## Epic
Implements #42 (child issues #43–#47).

## What changed
- **SKILL_TREE**: V-model row in Process Variations; full **Process overlay: V-model** section; summary table row; implementation status updates
- **COOPERATION**: V-model flow (mermaid), Agile/shift-left notes, retrofit + architecture link; new trigger rows
- **skills/v-model/**: orchestrator + -model-mapping, pairing sub-skills, **-model-retrofit** (explicit vs touch-driven)
- **plan** + **issue-workflow**: optional V-model / retrofit pointers + human-ai meta link
- **_meta/human-ai-execution.md**: labels + issue **Execution** template
- **README** + **CLAUDE**: discoverability for v-model and meta doc
- **Orchestrator stubs** (minimal): equirements/, design/, implementation/, alidation/, 	est/ parent SKILL.md so new links resolve

## GitHub
Labels created: execution:ai-ok, execution:human-review, execution:human-required, etrofit:explicit, etrofit:incremental

## Closing
Upon merge, close child issues (or edit checklist on epic #42).

Closes #43
Closes #44
Closes #45
Closes #46
Closes #47

Made with [Cursor](https://cursor.com)