### PR TITLE
feat(skills): sync portfolio skills from on_prem_rag

### DIFF
--- a/skills/COOPERATION.md
+++ b/skills/COOPERATION.md
@@ -18,10 +18,10 @@ Each step produces output for the next. No parallelism within this chain.
 ### TDD flow
 
 ```
-issue-acceptance-criteria → validation-draft → test-write → implementation-construction → validation-run
+issue-acceptance-criteria → validation-draft → create-validation (optional, full checklist) → test-write → implementation-construction → run-validation
 ```
 
-Validation and tests are drafted before implementation.
+Validation and tests are drafted before implementation. [create-validation](validation/create-validation/SKILL.md) and [run-validation](validation/run-validation/SKILL.md) add executable markdown checklists for issue-driven workflows.
 
 ## Parallel (independent) skills
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -59,6 +59,11 @@ skills/
 ├── _meta/              # Meta-skills
 │   └── skill-creation/
 │       └── SKILL.md
+├── api-design/
+├── branch-cleanup-after-pr/
+├── code-quality-design/
+├── code-quality-docs/
+├── code-quality-testing/
 ├── ideation/
 ├── requirements/
 ├── architecture/
@@ -66,7 +71,7 @@ skills/
 ├── issue-workflow/
 ├── plan/
 ├── implementation/
-├── validation/
+├── validation/         # validation-draft, create-validation, run-validation, skill-benchmark
 ├── test/
 ├── quality-gate/
 ├── integration/

--- a/skills/SKILL_TREE.md
+++ b/skills/SKILL_TREE.md
@@ -220,11 +220,14 @@ Drafts and executes validation steps; ensures acceptance criteria are met.
 Drafts validation steps, scenarios, or test cases from acceptance criteria (BDD/TDD).
 // Can run before implementation in TDD.
 
+#### 8.1b create-validation
+Creates full implementation validation documents: markdown checklists with exact commands, URLs, and expected outcomes; issue-scratch or committed paths. Complements validation-draft.
+
 #### 8.2 validation-detail
 Refines validation with implementation-specific details when code shape is known.
 
 #### 8.3 validation-run
-Executes validation checklist; records evidence.
+Executes validation checklist; records evidence. Implemented: [run-validation](validation/run-validation/SKILL.md).
 
 #### 8.4 skill-benchmark
 Evaluates skill effectiveness by comparing agent output on a task with and without the skill; produces a scored comparison table.
@@ -384,7 +387,7 @@ Explains git worktrees and Claude Code usage; guides removal and cleanup when a 
 | 5 | issue-workflow | Issue lifecycle | 5.1–5.7 |
 | 6 | plan | Planning | 6.1–6.3 |
 | 7 | implementation | Construction | 7.1–7.3 |
-| 8 | validation | Validation | 8.1–8.3 |
+| 8 | validation | Validation | 8.1–8.4, 8.1b |
 | 9 | test | Testing | 9.1–9.3 |
 | 10 | quality-gate | Quality | 10.1–10.5 |
 | 11 | integration | Integration | 11.1–11.3 |
@@ -406,6 +409,8 @@ Explains git worktrees and Claude Code usage; guides removal and cleanup when a 
 | design (4.1) | ✅ implemented |
 | implementation (7.1) | ✅ implemented |
 | validation (8.1) | ✅ implemented |
+| create-validation (8.1b), run-validation (8.3) | ✅ implemented |
+| api-design, branch-cleanup-after-pr, code-quality-design/docs/testing | ✅ implemented |
 | quality-gate (10.x) | ✅ implemented |
 | openclaw-security (10.5) | ✅ implemented |
 | integration (11.x) | ✅ implemented |

--- a/skills/api-design/SKILL.md
+++ b/skills/api-design/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: api-design
+description: Enforce API design rules when adding or changing endpoints. Apply REST conventions, versioning, deduplication semantics, OpenAPI documentation.
+---
+
+# API Design
+
+Use when designing new HTTP APIs, refactoring routes, or reviewing API changes.
+
+## When to Invoke
+
+- Adding a new route or router
+- Changing request/response models
+- Reviewing API documentation (OpenAPI, `/docs`, `/redoc`)
+- Deciding between a new endpoint vs extending an existing one
+
+## Core Rules
+
+### 1. HTTP Verbs and Status Codes
+
+| Verb | Use | Idempotent |
+|------|-----|------------|
+| GET | Retrieve, list, health | Yes |
+| POST | Create, actions (domain operations) | No (unless designed idempotent) |
+| PUT | Replace resource | Yes |
+| DELETE | Remove | Yes |
+
+**Upload / create semantics (common pattern)**:
+
+- New resource: **201 Created** with a clear body
+- Duplicate or idempotent hit (e.g. same hash): **200 OK** with a flag such as `created: false` — no duplicate side effects
+
+### 2. Resource Naming
+
+- Plural nouns: `/api/documents`, not `/api/document`
+- Hierarchical: `/api/documents/{id}/chunks`
+- No verbs in URLs; use HTTP method
+- RPC-style actions are acceptable for domain operations when they fit the product: `/api/ask`, `/api/transcribe`
+
+### 3. New vs Extend
+
+**Create new** when: different resource, different contract, clear separation.
+**Extend** when: same resource, minor variant, additive parameters.
+
+### 4. Anti-Patterns
+
+- **Duplicate endpoints** for the same operation (e.g. legacy `/api/v0/upload` next to `/api/v1/documents`) — consolidate behind one versioned surface.
+- **Overlapping semantics** across routers — unify the contract.
+- **Missing OpenAPI metadata** — add tags, summary, description, examples.
+
+### 5. Checklist Before PR
+
+- Correct HTTP verb
+- Consistent naming
+- OpenAPI tags, description, examples
+- Pydantic models or equivalent for request/response
+- Tests for the route or handler
+- Project API index or changelog updated if your repo maintains it
+
+## References
+
+- Project-specific rules: often under `.cursor/rules/` (e.g. `api-design.mdc`)
+- Technical docs: e.g. `docs/technical/API_DESIGN.md`, `API_ENDPOINTS.md` when present

--- a/skills/branch-cleanup-after-pr/SKILL.md
+++ b/skills/branch-cleanup-after-pr/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: branch-cleanup-after-pr
+description: Sync local branches after a PR is merged. Checkout main, pull, fetch --prune, delete local branches that are merged or track gone remotes. Use when a PR was just merged (merge, squash, or rebase) or when local branch list is stale.
+---
+
+# Branch Cleanup After PR Merge
+
+When a PR is merged (merge commit, squash-merge, or rebase-merge), run this to sync local state and remove obsolete branches.
+
+Complements [maintenance-cleanup](../maintenance/maintenance-cleanup/SKILL.md) (broader hygiene) and [git-worktrees](../git-worktrees/SKILL.md) — use worktrees when branch deletion fails.
+
+## Workflow
+
+1. **Checkout main, pull**
+   ```bash
+   git checkout main
+   git pull
+   ```
+
+2. **Fetch with prune** (removes refs for deleted remote branches)
+   ```bash
+   git fetch --prune
+   ```
+
+3. **Identify branches to delete**
+   - **Merge commits**: `git branch --merged main` — branch tip is in main's history
+   - **Squash/rebase**: `git branch -vv | grep ': gone]'` — remote was deleted on GitHub after merge
+
+4. **Delete local branches**
+   - From --merged list (exclude main)
+   - From gone list: extract branch name, run `git branch -d <name>`
+
+## Merge Type Coverage
+
+| Type | Detection | Notes |
+|------|-----------|-------|
+| Merge commit | `--merged main` | Branch tip is ancestor of main |
+| Squash merge | `: gone]` after prune | Remote branch deleted; commits not in main's history |
+| Rebase merge | `: gone]` after prune | Same as squash |
+
+## Protected Branches
+
+Never delete: `main`, `master`, `develop`, `release/*`, `hotfix/*`
+
+## Cross-Platform
+
+- **PowerShell**: Use `Select-String` instead of `grep`; chain with `;` not `&&` where needed
+- **Bash**: Standard grep/awk/sed
+
+## Reference
+
+Some repos keep copy-paste commands under `.cursor/commands/branch-cleanup.md` — optional.

--- a/skills/code-quality-design/SKILL.md
+++ b/skills/code-quality-design/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: code-quality-design
+description: Apply complexity management, naming, and function design principles from Code Complete 2 and A Philosophy of Software Design. Use when designing modules, refactoring, or reviewing code for structural quality.
+---
+
+# Code Quality: Design and Structure
+
+Principles from McConnell and Ousterhout. Apply by default on every generation, refactor, and review.
+
+## Complexity Management
+
+- **Primary goal**: Reduce complexity — anything that makes code harder to understand or modify.
+- **Never add complexity for anticipated future needs.** Build what is required now.
+- **Isolate complexity.** If logic is inherently complex, contain it in one module with a simple interface. Do not leak into callers.
+- **Avoid tactical programming.** Do not take shortcuts that create confusion tomorrow. If a design feels wrong, propose an alternative before implementing.
+
+## Naming
+
+Names are the primary documentation. A good name lets the reader skip the implementation.
+
+- **Precise and unambiguous.** Avoid: `data`, `result`, `info`, `manager`, `handler`, `helper`, `utils`. Prefer domain-specific names such as `chunked_document`, `embedding_response`, `pii_scan_result`.
+- **Function names describe what they return or do**, not how: `get_relevant_chunks()` not `run_vector_search_and_filter()`.
+- **Booleans** read as true/false: `is_authenticated`, `has_audit_trail`, `requires_network`.
+- **Do not abbreviate** unless domain-standard (e.g. `jwt`, `api`, `llm`).
+- **Consistency.** If one module uses `document`, do not use `doc`, `file`, or `artifact` elsewhere for the same concept.
+
+## Function and Module Design
+
+- **Functions do one thing.** If you need "and" to describe it, split. Can you write a one-line docstring without "and"?
+- **Deep modules, shallow interfaces.** Hide complexity behind minimal, stable interfaces. Prefer fewer, richer public functions.
+- **Function length = cohesion.** Many lines serving one purpose can be fine. A few lines doing two unrelated things is too long.
+- **Limit parameters to four or fewer.** Use structured models (Pydantic, dataclasses, typed structs) for more.
+- **Avoid flag parameters** (`process(doc, is_streaming=True)`). They signal two behaviours — split instead.
+- **Files under ~500 lines** (project convention). If larger, split by responsibility.

--- a/skills/code-quality-docs/SKILL.md
+++ b/skills/code-quality-docs/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-quality-docs
+description: Apply comment and documentation standards for Python code. Use when writing docstrings, adding comments, or marking technical debt (TODOs). Ensures explain-why-not-what and traceable debt.
+---
+
+# Code Quality: Documentation and Comments
+
+Comments explain **why**, not **what**. Code should be self-documenting.
+
+## Docstrings
+
+- **Write the docstring before implementation.** If you cannot summarize in one sentence, the design is not clear yet.
+- **Complete docstrings for public and core functions:** Args, Returns, Raises, and examples for complex functions. Follow your project's function-definition rules (often under `.cursor/rules/`).
+- **Explain non-obvious decisions.** If a threshold, chunk size, or algorithm was chosen for a specific reason (benchmark, compliance, environment limit), document it.
+
+## Comments
+
+- **Do not comment what the code already says.** Remove noise.
+- **Explain why** when the reason is not obvious from code alone.
+
+## Technical Debt (TODOs)
+
+- **Prefer task reference:** `# TODO(TASK-NNN): …` or `# TODO(#123): …` when your repo issues map that way
+- **Alternative:** One SMART sentence when no task exists yet: unambiguous, actionable, discoverable
+
+Never use a bare `# TODO` without either a task ID or a complete, self-contained description.

--- a/skills/code-quality-testing/SKILL.md
+++ b/skills/code-quality-testing/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: code-quality-testing
+description: Apply testing efficiency and effectiveness principles. Use when writing tests, reviewing test suites, or improving test coverage. Emphasizes behavioral coverage and mutation-aware assertions.
+---
+
+# Code Quality: Testing
+
+Tests are production code. Apply the same quality standards.
+
+## Structure
+
+- **Every test tests one behavior.** A failing test should tell you exactly what broke without reading the test body.
+- **Test names are sentences:** `test_chunker_splits_on_sentence_boundary_not_word_boundary` is better than `test_chunker_2`.
+- **Test docstrings:** Prefer user-facing phrasing (objective, benefit) for product-facing tests; for utilities, a concise one-liner or full docstring per project standards (often under `.cursor/rules/`).
+
+## Efficiency
+
+- **Prefer narrow, fast unit tests.** Mock external dependencies at boundaries — not deep inside pure logic.
+- **Mark slow or external tests** with your project's markers (`slow`, `integration`, `docker`, etc.).
+- **Avoid duplication.** Use `parametrize` or shared fixtures when the same shape repeats with small variations.
+
+## Effectiveness
+
+- **Mutation-aware assertions:** Assert specific outcomes. An assertion that passes when the condition is inverted does not test anything.
+- **Coverage is a floor, not a goal.** Prefer behavioural coverage over line coverage.

--- a/skills/maintenance/maintenance-cleanup/SKILL.md
+++ b/skills/maintenance/maintenance-cleanup/SKILL.md
@@ -16,6 +16,8 @@ Post-merge hygiene: branch cleanup, worktree removal, GitHub Actions runs, tmp/ 
 
 ## Branch cleanup
 
+For a full PR-merge checklist (merge, squash, rebase, `gone` remotes), see [branch-cleanup-after-pr](../../branch-cleanup-after-pr/SKILL.md).
+
 1. `git checkout main`, `git pull`
 2. `git branch -d <branch>` (or `-D` if squash-merged)
 3. `git fetch --prune` to remove stale remote-tracking refs

--- a/skills/validation/SKILL.md
+++ b/skills/validation/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: validation
+description: Drafts and executes validation steps; ensures acceptance criteria are met. Use when working in lifecycle area 8.x per SKILL_TREE.
+---
+
+# Validation (orchestrator)
+
+Canonical index: [SKILL_TREE.md](../SKILL_TREE.md) §8.
+
+Implemented: [validation-draft](validation-draft/SKILL.md), [create-validation](create-validation/SKILL.md), [run-validation](run-validation/SKILL.md), [skill-benchmark](skill-benchmark/SKILL.md). V-model links: [v-model-mapping](../v-model/v-model-mapping/SKILL.md).

--- a/skills/validation/create-validation/SKILL.md
+++ b/skills/validation/create-validation/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: create-validation
+description: Create an implementation validation document for a feature or issue. Produces a step-by-step checklist with exact commands, URLs, and expected outcomes. Use after implementation planning or before PR creation to define how the feature can be verified end-to-end.
+---
+
+# Create Implementation Validation
+
+A validation document proves an implementation is complete. It is executable: each step is a concrete action (command, URL, UI check) with an explicit expected outcome.
+
+Works with [validation-draft](../validation-draft/SKILL.md) (criteria → steps) and [run-validation](../run-validation/SKILL.md) (execute the checklist).
+
+## When to Use
+
+- After planning is complete — create validation so it guides implementation
+- Before creating a PR — validate against the spec
+- When acceptance criteria must be verified, not only asserted
+
+## Format
+
+If your project defines a schema (e.g. `docs/technical/VALIDATION_FORMAT.md`), follow it. Otherwise use the step structure below.
+
+## Storage
+
+| Scope | Typical location |
+|-------|------------------|
+| Issue-scoped (ephemeral) | `tmp/github/issue-NNN/validation.md` or project scratch layout |
+| Feature-scoped (committed) | `docs/validations/<feature>-validation.md` |
+
+Default to ephemeral scratch unless the user asks for a committed validation.
+
+## How to Create a Validation
+
+### 1. Gather Context
+
+Read: issue acceptance criteria, implementation plan, API docs, ports, and run commands from the repo README or `CLAUDE.md`.
+
+### 2. Identify Validation Steps
+
+Map each acceptance criterion to verifiable steps:
+
+- **Does it run?** → test command
+- **Does the API respond correctly?** → HTTP request with expected status + body
+- **Is the UI visible/functional?** → URL + what to click or observe
+- **Does it integrate?** → end-to-end scenario
+
+### 3. Write Steps
+
+Each step must have:
+
+- **Action**: exact command or exact UI instruction
+- **Expected**: explicit outcome (exit code, output substring, HTTP code — not "it works")
+- **Checkbox**: `- [ ] Step passed`
+
+**Step ordering**: simple → complex; unit → integration → end-to-end.
+
+### 4. Prerequisites
+
+List what must be running before step one, with commands to start services if needed.
+
+### 5. Goal
+
+One sentence: what this validation proves.
+
+## Quality Bar
+
+- Executable by someone who did not write the code
+- No ambiguous expectations ("visible", "works" without specifics)
+- Covers the critical path, not every edge case
+
+## Example Step (Good vs Bad)
+
+**Bad:** "Upload a file. Expected: works."
+
+**Good:** Exact `curl` or UI path, expected HTTP code and JSON fields (or UI state).
+
+## References
+
+- [run-validation](../run-validation/SKILL.md) — executes this checklist

--- a/skills/validation/run-validation/SKILL.md
+++ b/skills/validation/run-validation/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: run-validation
+description: Execute an implementation validation file step by step. For each step, run the command or check the UI, compare to the expected outcome, check off passing steps, and document failures. When a step fails, attempt to diagnose and fix the issue, then update the validation with corrected steps or expectations. Use after implementation to verify a feature is complete.
+---
+
+# Run Implementation Validation
+
+Reads a validation file, executes each step, tracks pass/fail, and iterates on failures.
+
+Pairs with [create-validation](create-validation/SKILL.md).
+
+## When to Use
+
+- After completing implementation
+- Before opening a PR — gate on all steps passing
+- During development — partial runs for work-in-progress
+
+## Inputs
+
+The user provides one of:
+
+- An issue number → look for `tmp/github/issue-NNN/validation.md` (or project convention)
+- A file path → read that file
+- Nothing → list available validation files and ask the user to select
+
+## Execution Protocol
+
+### Phase 1: Load Validation
+
+1. Read the validation file
+2. If frontmatter `status` is `passed`, confirm whether to re-run
+3. List steps and checkbox state
+4. Report title and step counts
+
+### Phase 2: Execute Steps Sequentially
+
+For each unchecked step (in order):
+
+#### 2a. Execute the Action
+
+- **CLI**: Run; capture stdout, stderr, exit code
+- **HTTP**: Capture body + status code
+- **UI**: Navigate and observe (browser tools if available)
+- **File / log**: Read or tail as specified
+
+#### 2b. Compare to Expected
+
+Determine **PASS** or **FAIL**. On PASS, set checkbox to `[x]`. On FAIL, report actual vs expected.
+
+#### 2c. On Failure — Diagnose and Fix
+
+1. **Diagnose:** implementation bug, environment (service down), wrong expectation in file, or outdated command
+2. **Fix:** code, start services, or correct the validation file — document why
+3. **Re-run** the step after fixes
+4. If still blocked, mark blocked and document; stop if a prerequisite step cannot pass
+
+#### 2d. Blocking Failures
+
+If a prerequisite step fails (e.g. app will not start), stop and set overall status `failed`.
+
+### Phase 3: Final Report
+
+Count passed / failed / blocked. Set frontmatter `status` to `passed` or `failed`. Summarize for the user.
+
+### Phase 4: Post-Validation
+
+- If passed: optional `gh issue comment` or checklist updates on the issue
+- If failed: list next actions
+
+## Rules
+
+- **Do not skip steps** unless the user explicitly scopes a partial run
+- **Do not mark passed** without executing and verifying
+- **Document** why an expectation or command was corrected
+- **Fix implementation first** — change the validation only when the spec was wrong
+
+## References
+
+- [create-validation](create-validation/SKILL.md)
+- [validation-draft](validation-draft/SKILL.md)


### PR DESCRIPTION
## Summary
Ports seven skill areas from **on_prem_rag** into the canonical \skills/\ tree (portfolio-neutral wording).

## Mapping (audit)
| Source (on_prem_rag) | Action |
|----------------------|--------|
| api-design | New \skills/api-design/\ — REST, versioning, checklist |
| branch-cleanup-after-pr | New \skills/branch-cleanup-after-pr/\ — complements maintenance-cleanup |
| code-quality-design/docs/testing | New \skills/code-quality-*\ — McConnell/Ousterhout + docs + tests |
| create-validation, run-validation | New under \skills/validation/\ — executable issue checklists |
| validation orchestrator | New \skills/validation/SKILL.md\ linking sub-skills |

## Docs
- SKILL_TREE: 8.1b create-validation, 8.3 → run-validation link
- COOPERATION: TDD flow mentions create-validation / run-validation
- README: directory structure updated
- maintenance-cleanup → links branch-cleanup-after-pr

## Consumer
**on_prem_rag** will symlink \.cursor/skills\ → \../pkuppens/skills\ after merge.

Made with [Cursor](https://cursor.com)