### PR TITLE
#32: Agent Skills spec validation CI and ADR

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -1,0 +1,55 @@
+# Validate SKILL.md frontmatter against agentskills.io (skills-ref).
+# See docs/skills/decisions/001-skill-validation-and-tooling.md
+name: Validate skills
+
+on:
+  pull_request:
+    paths:
+      - "skills/**"
+      - ".github/workflows/validate-skills.yml"
+  push:
+    branches: [main]
+    paths:
+      - "skills/**"
+      - ".github/workflows/validate-skills.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: validate-skills-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install skills-ref (pinned)
+        run: npm install -g skills-ref@0.1.5
+
+      - name: Validate each skill directory
+        shell: bash
+        run: |
+          set -euo pipefail
+          failed=0
+          while IFS= read -r -d '' skill_md; do
+            dir=$(dirname "$skill_md")
+            echo "::group::Validate $dir"
+            if ! skills-ref validate "$dir"; then
+              failed=1
+            fi
+            echo "::endgroup::"
+          done < <(find skills -name 'SKILL.md' -print0)
+          if [[ "$failed" -ne 0 ]]; then
+            echo "One or more skills failed validation."
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ The `pkuppens/pkuppens` GitHub profile repository. It serves two purposes:
 1. **GitHub profile README** (`README.md`) — displayed at `github.com/pkuppens`.
 2. **Unified AI coding skills library** (`skills/`) — shared `SKILL.md` files for Cursor, Claude, and Codex.
 
-There is no build system, test suite, or linting pipeline. All content is Markdown.
+There is no build system or test suite. All content is Markdown. Skills under `skills/` are checked in CI: [`validate-skills.yml`](.github/workflows/validate-skills.yml); see [ADR 001](docs/skills/decisions/001-skill-validation-and-tooling.md).
 
 ## Repository Layout
 
@@ -23,7 +23,10 @@ pkuppens/
 │   │   └── SKILL.md
 │   └── <skill-name>/            # One directory per skill (mostly not yet created)
 │       └── SKILL.md
-├── docs/screenshots/            # Assets referenced from README.md
+├── docs/
+│   ├── screenshots/             # Assets referenced from README.md
+│   └── skills/
+│       └── decisions/           # ADRs for the skills library (e.g. validation tooling)
 └── tmp/                         # Gitignored scratch (drafts, planning)
 ```
 

--- a/docs/skills/decisions/001-skill-validation-and-tooling.md
+++ b/docs/skills/decisions/001-skill-validation-and-tooling.md
@@ -1,0 +1,38 @@
+# ADR 001: Skill validation tooling and CI
+
+**Status:** Accepted  
+**Date:** 2026-03-26  
+**Context:** [GitHub issue #32](https://github.com/pkuppens/pkuppens/issues/32) — parent [issue #26](https://github.com/pkuppens/pkuppens/issues/26) (Skilz as install mechanism, deferred)
+
+## Context
+
+This repository maintains a unified library of Agent Skills under `skills/`. Each skill is a directory containing `SKILL.md` with YAML frontmatter. Consumers link `skills/` into Cursor (`.cursor/skills/`), Claude (`.claude/skills/`), or Codex (`~/.codex/skills/`) per [skills/README.md](../../skills/README.md).
+
+**Canonical format** for portable skills is the [Agent Skills specification](https://agentskills.io/specification): required `name` and `description`, optional fields, and rules such as `name` matching the parent directory and character/length limits. Authoring conventions for this repo also live in [skills/CLAUDE.md](../../skills/CLAUDE.md) and [Claude — Agent Skills best practices](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/best-practices#skill-structure).
+
+**Skilz** ([SpillwaveSolutions/skilz-cli](https://github.com/SpillwaveSolutions/skilz-cli), PyPI package `skilz`, `pip install skilz`) is a **skill package manager** that installs skills into agent-specific locations. Its README states alignment with [agentskills.io](https://agentskills.io/) and the [AGENTS.md](https://agents.md/) ecosystem. It is **not** the definition of schema correctness for this repo: the spec is. Skilz remains an **optional** way for end users to install skills; whether the project promotes Skilz as the primary install path is still governed by #26.
+
+**Validation options considered:**
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **npm `skills-ref`** (pinned), `skills-ref validate <skill-dir>` | Referenced from the [specification page](https://agentskills.io/specification) as the reference validator; checks frontmatter against the spec. | The [npm package](https://www.npmjs.com/package/skills-ref) states it is for **demonstration purposes** and not production — acceptable for a lightweight Markdown repo CI if we treat it as “best available spec-aligned checker” and revisit if the upstream stance changes. |
+| **Skilz CLI** | Same ecosystem as a future install story. | Not documented as a dedicated bulk `SKILL.md` linter in the upstream README; primary focus is install/list/search. |
+| **Custom script** (e.g. Python + PyYAML) | Full control, no npm disclaimer. | Duplicates spec rules; maintenance burden when the spec evolves. |
+
+## Decision
+
+1. **Source of truth** for machine-checkable skill metadata remains **[agentskills.io](https://agentskills.io/specification)**.
+2. **CI** runs **`skills-ref`** (global npm install, **version pinned** in [.github/workflows/validate-skills.yml](../../../.github/workflows/validate-skills.yml)) against **each** directory under `skills/` that contains `SKILL.md`.
+3. **Skilz** is documented here as an **optional installer** for consumers, not as the validator for this repository.
+4. **Revisit** this ADR if: `skills-ref` gains a production-ready designation, Skilz ships a first-class validate command we prefer, or we adopt a different official validator from the agentskills project.
+
+## Consequences
+
+- Pull requests that change files under `skills/` trigger validation; unrelated edits stay quiet (path filter on the workflow).
+- Contributors see failures in GitHub Actions instead of only when loading a skill in an IDE.
+- If `skills-ref` drifts from the spec or becomes unmaintained, swap the workflow step and update this ADR.
+
+## Cursor and Claude
+
+Both load `SKILL.md` from configured skill directories. **Spec-compliant** frontmatter is the shared baseline for interoperability. IDE-specific behaviour beyond the spec is out of scope for this ADR (see original #32 scope).

--- a/skills/CLAUDE.md
+++ b/skills/CLAUDE.md
@@ -18,8 +18,10 @@ This directory contains unified AI coding skills for Cursor, Claude, and Codex. 
 
 1. Use [skill-creation](_meta/skill-creation/SKILL.md) for new skills
 2. Follow SKILL_TREE.md principles: single responsibility, one-liner, progressive disclosure
-3. Conform to [Claude skill structure](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/best-practices#skill-structure): YAML frontmatter (name, description), concise body, progressive disclosure
+3. Conform to [Claude skill structure](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/best-practices#skill-structure) and the [Agent Skills specification](https://agentskills.io/specification): YAML frontmatter (`name`, `description`), concise body, progressive disclosure. Quote `description` when it contains colons.
 4. Keep SKILL.md under ~300 lines; use reference.md, examples.md for details; add additional small skills when exceeding 300 lines.
+
+Validation policy: [ADR 001 — Skill validation and tooling](../docs/skills/decisions/001-skill-validation-and-tooling.md).
 
 ## Scratch
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -8,6 +8,8 @@ Skills are markdown files (`SKILL.md`) in skill-specific directories. Each skill
 
 Full skill tree: [SKILL_TREE.md](SKILL_TREE.md). How skills compose: [COOPERATION.md](COOPERATION.md). Optional **V-model** traceability overlay: [v-model/SKILL.md](v-model/SKILL.md).
 
+**Format and CI:** Metadata must follow the [Agent Skills specification](https://agentskills.io/specification). Pull requests that touch `skills/` run automated validation (`skills-ref`, pinned in GitHub Actions). Tooling choices and Skilz vs spec are documented in [ADR 001 — Skill validation and tooling](../docs/skills/decisions/001-skill-validation-and-tooling.md).
+
 ## IDE Setup
 
 Reference this `skills/` folder from your IDE. Do not duplicate skills. Symlinks below work for **Cursor**, **Claude**, and **Codex**.

--- a/skills/architecture/architecture-building-blocks/SKILL.md
+++ b/skills/architecture/architecture-building-blocks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: architecture-building-blocks
-description: Documents static decomposition: hierarchy and black-box/white-box view of building blocks. Use when defining structure for a new system; produces arc42 §5 content.
+description: "Documents static decomposition: hierarchy and black-box/white-box view of building blocks. Use when defining structure for a new system; produces arc42 §5 content."
 ---
 
 # Architecture Building Blocks

--- a/skills/architecture/architecture-crosscutting/SKILL.md
+++ b/skills/architecture/architecture-crosscutting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: architecture-crosscutting
-description: Documents crosscutting concepts: dependency rules, layering, and architecture tests. Use when enforcing constraints or detecting architecture drift; produces arc42 §8 content.
+description: "Documents crosscutting concepts: dependency rules, layering, and architecture tests. Use when enforcing constraints or detecting architecture drift; produces arc42 §8 content."
 ---
 
 # Architecture Crosscutting

--- a/skills/architecture/architecture-runtime/SKILL.md
+++ b/skills/architecture/architecture-runtime/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: architecture-runtime
-description: Documents runtime behaviour: technical execution paths, component interactions, sequences (arc42 §6). Use when documenting flows or tracing execution.
+description: "Documents runtime behaviour: technical execution paths, component interactions, sequences (arc42 §6). Use when documenting flows or tracing execution."
 ---
 
 # Architecture Runtime

--- a/skills/implementation/implementation-construction/SKILL.md
+++ b/skills/implementation/implementation-construction/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implementation-construction
-description: Writes new code following Code Complete 2 construction principles: consistent naming, single responsibility, type hints, docstrings, and minimal surface area. Use when implementing a designed component or function; follows design-consult output.
+description: "Writes new code following Code Complete 2 construction principles: consistent naming, single responsibility, type hints, docstrings, and minimal surface area. Use when implementing a designed component or function; follows design-consult output."
 ---
 
 # Implementation Construction


### PR DESCRIPTION
Closes #32

This PR adds path-filtered CI validation of every skill directory using pinned \skills-ref\, documents the decision in ADR 001, and fixes YAML frontmatter on four skills where unquoted colons in \description\ broke the parser.

- **Workflow:** [.github/workflows/validate-skills.yml](.github/workflows/validate-skills.yml)
- **ADR:** [docs/skills/decisions/001-skill-validation-and-tooling.md](docs/skills/decisions/001-skill-validation-and-tooling.md)
- **Issue #32** updated on GitHub with the new Why, goals, references, and acceptance criteria.

Made with [Cursor](https://cursor.com)