### PR TITLE
docs(skills): add code-review skill (PR #151 lessons)

### DIFF
--- a/docs/skills/audit-results.md
+++ b/docs/skills/audit-results.md
@@ -8,13 +8,13 @@
 
 ## Executive summary
 
-Audit of 82+ skill files across workspace locations. Canonical set: `pkuppens/skills/` (37 SKILL.md files). Overlaps identified; mapping table below. `babblr` has no skills. `~/.claude/skills` not audited (likely symlinked to pkuppens or user-specific).
+Audit of 82+ skill files across workspace locations. Canonical set: `pkuppens/skills/` (38 SKILL.md files). Overlaps identified; mapping table below. `babblr` has no skills. `~/.claude/skills` not audited (likely symlinked to pkuppens or user-specific).
 
 ---
 
 ## 1. Inventory by location
 
-### 1.1 pkuppens/skills/ (canonical) — 37 files
+### 1.1 pkuppens/skills/ (canonical) — 38 files
 
 | Path | Canonical equivalent |
 |------|----------------------|
@@ -31,9 +31,10 @@ Audit of 82+ skill files across workspace locations. Canonical set: `pkuppens/sk
 | design/design-consult/SKILL.md | 4.1 design-consult |
 | find-skills/SKILL.md | find-skills |
 | implementation/implementation-construction/SKILL.md | 7.1 implementation-construction |
+| code-review/SKILL.md | 11.3 code-review |
 | integration/SKILL.md | 11 integration (orchestrator) |
 | integration/integration-commit/SKILL.md | 11.1 integration-commit |
-| integration/integration-merge/SKILL.md | 11.3 integration-merge |
+| integration/integration-merge/SKILL.md | 11.4 integration-merge |
 | integration/integration-pr/SKILL.md | 11.2 integration-pr |
 | issue-workflow/SKILL.md | 5 issue-workflow (orchestrator) |
 | issue-workflow/issue-acceptance-criteria/SKILL.md | 5.4 issue-acceptance-criteria |

--- a/skills/COOPERATION.md
+++ b/skills/COOPERATION.md
@@ -8,7 +8,7 @@ How skills compose: sequential vs parallel flows, triggers, and dependencies.
 
 ```
 issue-workflow → plan → architecture (or architecture-consult) → design-consult
-  → implementation-construction → quality-gate → integration-commit → integration-pr → integration-merge
+  → implementation-construction → quality-gate → integration-commit → integration-pr → code-review → integration-merge
 ```
 
 During issue creation or revision, **architecture** (orchestrator or sub-skills) can be triggered before or during purpose-alignment, work-down, or acceptance-criteria so requirements and implementation plans reflect architecture concerns.
@@ -86,7 +86,7 @@ Also: architecture-runtime (flows), architecture-crosscutting (rules), architect
 ## Deployment flow
 
 ```
-quality-gate → integration-commit → integration-pr → integration-merge
+quality-gate → integration-commit → integration-pr → code-review → integration-merge
   → deployment-build → deployment-release → operations-monitoring
 ```
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -65,6 +65,7 @@ skills/
 ├── code-quality-design/
 ├── code-quality-docs/
 ├── code-quality-testing/
+├── code-review/        # PR review checklist (imports, headers, compliance wording)
 ├── ideation/
 ├── requirements/
 ├── architecture/

--- a/skills/SKILL_TREE.md
+++ b/skills/SKILL_TREE.md
@@ -284,7 +284,10 @@ Commits with conventional message; references issue.
 #### 11.2 integration-pr
 Opens PR; links to issue; fills description.
 
-#### 11.3 integration-merge
+#### 11.3 code-review
+Structured PR review: module headers, absolute imports, domain-neutral compliance language, naming (`logger` vs internal `_` conventions), security spot checks. Use before merge.
+
+#### 11.4 integration-merge
 Merges PR; resolves conflicts; squashes if needed.
 
 ---
@@ -418,7 +421,7 @@ Explains git worktrees and Claude Code usage; guides removal and cleanup when a 
 | 8 | validation | Validation | 8.1–8.4, 8.1b |
 | 9 | test | Testing | 9.1–9.3 |
 | 10 | quality-gate | Quality | 10.1–10.5 |
-| 11 | integration | Integration | 11.1–11.3 |
+| 11 | integration | Integration | 11.1–11.4 |
 | 12 | deployment | Deployment | 12.1, 12.2 |
 | 13 | operations | Production, monitoring, audit | 13.1–13.3 |
 | 14 | maintenance | Bug report, cleanup, debt | 14.1–14.3 |
@@ -429,7 +432,7 @@ Explains git worktrees and Claude Code usage; guides removal and cleanup when a 
 
 ## Implementation Status
 
-*Post-audit #27: 37 SKILL.md files in pkuppens/skills. See [audit-results.md](../docs/skills/audit-results.md) for full inventory and mapping.*
+*Post-audit #27 (updated): 38 SKILL.md files in pkuppens/skills. See [audit-results.md](../docs/skills/audit-results.md) for full inventory and mapping.*
 
 | Skill | Status |
 | skill-creation | ✅ implemented |
@@ -442,7 +445,7 @@ Explains git worktrees and Claude Code usage; guides removal and cleanup when a 
 | api-design, branch-cleanup-after-pr, code-quality-design/docs/testing | ✅ implemented |
 | quality-gate (10.x) | ✅ implemented |
 | openclaw-security (10.5) | ✅ implemented |
-| integration (11.x) | ✅ implemented |
+| integration (11.x), code-review (11.3) | ✅ implemented |
 | deployment (12.1, 12.2) | ✅ implemented |
 | operations (13.1–13.3) | ✅ implemented |
 | skill-benchmark (8.4) | ✅ implemented |

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: code-review
+description: Structured pull-request review checklist (imports, module headers, domain-neutral compliance language, naming). Use after opening a PR or when reviewing merged changes for lessons learned.
+---
+
+# Code review (PR)
+
+Use this skill for **human or AI-assisted** review of a pull request before merge, or for a **post-merge** retrospective to capture recurring gaps.
+
+## When to use
+
+- After [integration-pr](../integration/integration-pr/SKILL.md) opens a PR and before [integration-merge](../integration/integration-merge/SKILL.md).
+- When validating reviewer feedback against the branch (or `main` after merge).
+- When consolidating **lessons learned** into team habits (document in the repo or a retrospective note if the review surfaces process issues).
+
+## Position in the workflow
+
+1. Implementation and tests are in place.
+2. [quality-gate](../quality-gate/SKILL.md) passes locally (or CI is green).
+3. PR is opened ([integration-pr](../integration/integration-pr/SKILL.md)).
+4. **Run this checklist** on the diff (or on files touched).
+5. Address findings; re-run quality-gate if needed.
+6. Merge when approved ([integration-merge](../integration/integration-merge/SKILL.md)).
+
+Reason: CI catches many issues, but conventions below are easy to miss in large security or compliance PRs.
+
+## Checklist
+
+### 1. Module headers (Python)
+
+- [ ] **New or heavily changed** modules have a short **module docstring** at the top: purpose, main responsibilities, and where the module sits in the architecture (one short paragraph).
+- [ ] Avoid files that jump straight into `import` with no context when the module is non-trivial (services, middleware, API entrypoints).
+
+See [code-quality-docs](../code-quality-docs/SKILL.md) for docstring and comment standards.
+
+### 2. Imports: one source root
+
+- [ ] Prefer **absolute** imports from the project’s single package root (e.g. `from backend.some_package.module import ...`).
+- [ ] Do not mix **`from backend...`**, **`from src.backend...`**, and deep **relative** imports (`from ..x import y`) in the same file unless the repo explicitly allows an exception.
+- [ ] Align with the target repo’s `.cursor/rules` or `CLAUDE.md` (example: on-prem RAG uses `backend.*` from `src/` layout).
+
+Reason: mixed roots confuse reviewers and break refactors.
+
+### 3. Domain language in shared code
+
+- [ ] Shared middleware, security notes, and compliance-oriented comments use **neutral** terms where possible: **auditability**, **traceability**, **compliance**, **regulated environments** — not a single sector (e.g. “banking-only”) unless the artifact is explicitly scoped to that domain.
+
+Reason: the same controls often apply to healthcare, finance, and public sector; sector-specific wording belongs in sector-specific docs or ADRs.
+
+### 4. Naming conventions
+
+- [ ] **`logger` vs `_logger`**: Prefer `logger = logging.getLogger(__name__)` at module level for readability unless the repo mandates a private prefix.
+- [ ] **Leading underscore** on module-level names usually means “internal by convention,” not “name collision avoidance.” If the only goal is to avoid clashing with a standard library name, prefer a clearer name (e.g. `logger` does not clash with the `logging` module).
+- [ ] **`import foo as _foo`**: Often used to avoid re-export or to mark optional/heavy imports; do not mix unrelated underscore styles in one file without reason.
+
+Document team choice in the repo if reviewers repeatedly disagree.
+
+### 5. Security and compliance (spot check)
+
+- [ ] Cryptographic choices (password hashing, JWT validation, secrets) match the PR’s claims and tests.
+- [ ] **No secrets** in source; secret-scanning hooks or CI are respected when present.
+- [ ] Logging does not print **full tokens** or PII without policy alignment (truncate or hash where required).
+
+### 6. Tests
+
+- [ ] New behavior has tests; security-sensitive paths have **negative** tests (invalid token, wrong algorithm, etc.) where applicable.
+
+## Lessons learned (example: on_prem_rag PR #151)
+
+The following came from a real security/compliance hardening PR; they are now part of this checklist:
+
+- Add **module headers** where reviewers asked for parity with well-documented neighbors (e.g. middleware next to other middleware).
+- Replace **sector-specific** phrasing with **auditability / compliance** language in shared components.
+- Enforce **one import style** per file for `app.py`-style entrypoints.
+- Align **`_logger`** / **`logger`** with project readability goals, not only PEP 8 “internal” habits.
+
+## Integration
+
+- **Documentation depth**: [code-quality-docs](../code-quality-docs/SKILL.md).
+- **Construction habits**: [implementation-construction](../implementation/implementation-construction/SKILL.md).
+- **PR workflow**: [integration](../integration/SKILL.md), [integration-pr](../integration/integration-pr/SKILL.md).
+- **Before merge**: [quality-gate](../quality-gate/SKILL.md).
+
+## References
+
+- Agent Skills specification (frontmatter for `SKILL.md`): https://agentskills.io/specification

--- a/skills/find-skills/SKILL.md
+++ b/skills/find-skills/SKILL.md
@@ -52,7 +52,7 @@ npx skills find [query]
 For example:
 
 - User asks "how do I make my React app faster?" → `npx skills find react performance`
-- User asks "can you help me with PR reviews?" → `npx skills find pr review`
+- User asks "can you help me with PR reviews?" → Prefer this repo’s [code-review](../code-review/SKILL.md) checklist first; optionally `npx skills find pr review` for external ecosystem skills.
 - User asks "I need to create a changelog" → `npx skills find changelog`
 
 The command will return results like:

--- a/skills/integration/SKILL.md
+++ b/skills/integration/SKILL.md
@@ -16,14 +16,16 @@ Creates PR, merges to main, and ensures proper Git workflow per repo CLAUDE.md.
 
 1. **Commit** — [integration-commit](integration-commit/SKILL.md). Conventional message, issue reference.
 2. **PR** — [integration-pr](integration-pr/SKILL.md). Open PR, link issue, fill description.
-3. **Merge** — [integration-merge](integration-merge/SKILL.md). Merge, resolve conflicts, squash if needed.
+3. **Review** — [code-review](../code-review/SKILL.md). Structured checklist on the diff (imports, headers, domain-neutral compliance wording, naming, security spot checks).
+4. **Merge** — [integration-merge](integration-merge/SKILL.md). Merge, resolve conflicts, squash if needed.
 
 ## Instructions
 
 1. Ensure quality-gate passes (lint, format, tests).
 2. Run integration-commit; stage and commit with conventional message.
 3. Push branch; run integration-pr to open PR.
-4. After review/approval, run integration-merge.
+4. Run code-review on the PR (or assign a human reviewer using the same checklist).
+5. After review/approval, run integration-merge.
 
 ## Prerequisites
 

--- a/skills/integration/integration-pr/SKILL.md
+++ b/skills/integration/integration-pr/SKILL.md
@@ -48,4 +48,4 @@ Closes #8"
 ## Integration
 
 - Runs after [integration-commit](../integration-commit/SKILL.md).
-- Feeds into [integration-merge](../integration-merge/SKILL.md).
+- Feeds into [code-review](../../code-review/SKILL.md), then [integration-merge](../integration-merge/SKILL.md).


### PR DESCRIPTION
## Summary

Adds a canonical **code-review** skill under \skills/code-review/\ with a PR review checklist (module headers, absolute imports, domain-neutral compliance language, logger naming, security spot checks). Lessons consolidated from \on_prem_rag\ [PR #151](https://github.com/pkuppens/on_prem_rag/pull/151) / issue #89.

## Changes

- New \skills/code-review/SKILL.md\ (validated with \skills-ref@0.1.5\)
- Register as **11.3 code-review**; **integration-merge** renumbered to **11.4** in SKILL_TREE and \docs/skills/audit-results.md\
- Update integration orchestrator, COOPERATION.md, integration-pr, find-skills; inventory count 37 → 38

## Out of scope

- No application code changes in \on_prem_rag\ (follow-up PR optional for audit_log wording, auth_service header, import normalization).

Made with [Cursor](https://cursor.com)