### PR TITLE
#67: feat: issue-gh-bulk-scratch + SKILL_TREE 5.8 + assignee alignment

### DIFF
--- a/skills/SKILL_TREE.md
+++ b/skills/SKILL_TREE.md
@@ -176,6 +176,9 @@ Adds T-shirt size (or equivalent) estimate.
 #### 5.7 issue-metadata
 Adds tags, milestones, assignees, planning references.
 
+#### 5.8 issue-gh-bulk-scratch
+Creates an EPIC and many issues with `gh`; keeps gitignored `tmp/` body files named 1-1 with GitHub issue numbers; self-assigns.
+
 ---
 
 ## Level 1: Planning
@@ -415,7 +418,7 @@ Explains git worktrees and Claude Code usage; guides removal and cleanup when a 
 | 2 | requirements | Requirements (arc42 §1–3) | 2.1–2.6 |
 | 3 | architecture | arc42 §4–12 | 3.1–3.10 |
 | 4 | design | Detailed design | 4.1–4.4 |
-| 5 | issue-workflow | Issue lifecycle | 5.1–5.7 |
+| 5 | issue-workflow | Issue lifecycle | 5.1–5.8 |
 | 6 | plan | Planning | 6.1–6.3 |
 | 7 | implementation | Construction | 7.1–7.3 |
 | 8 | validation | Validation | 8.1–8.4, 8.1b |
@@ -432,7 +435,7 @@ Explains git worktrees and Claude Code usage; guides removal and cleanup when a 
 
 ## Implementation Status
 
-*Inventory: **94** `SKILL.md` files under `pkuppens/skills/` (2026-04-10, #57, #59–#65). See [audit-results.md](../docs/skills/audit-results.md) for how to regenerate the list.*
+*Inventory: **95** `SKILL.md` files under `pkuppens/skills/` (2026-05-01, #57, #59–#65, #67). See [audit-results.md](../docs/skills/audit-results.md) for how to regenerate the list.*
 
 | Skill | Status |
 | skill-creation | ✅ implemented |

--- a/skills/branch-cleanup-after-pr/SKILL.md
+++ b/skills/branch-cleanup-after-pr/SKILL.md
@@ -24,19 +24,26 @@ Complements [maintenance-cleanup](../maintenance/maintenance-cleanup/SKILL.md) (
 
 3. **Identify branches to delete**
    - **Merge commits**: `git branch --merged main` — branch tip is in main's history
-   - **Squash/rebase**: `git branch -vv | grep ': gone]'` — remote was deleted on GitHub after merge
+   - **Gone upstream**: `git branch -vv | grep ': gone]'` — remote ref was deleted on GitHub
+   - **Functional merge (patch-equivalent after squash/rebase/cherry-pick)**:
+     - `git cherry -v main <branch>`
+     - If all branch commits show `-`, the branch changes are already in `main` even when ancestry differs
 
 4. **Delete local branches**
-   - From --merged list (exclude main)
-   - From gone list: extract branch name, run `git branch -d <name>`
+   - From `--merged` list (exclude protected branches), run `git branch -d <name>`
+   - From `: gone]` list:
+     - Try `git branch -d <name>`
+     - If blocked as "not fully merged", verify with `git cherry -v main <name>`
+     - If commits are all `-`, delete with `git branch -D <name>` (safe because patches already exist in `main`)
 
 ## Merge Type Coverage
 
 | Type | Detection | Notes |
 |------|-----------|-------|
 | Merge commit | `--merged main` | Branch tip is ancestor of main |
-| Squash merge | `: gone]` after prune | Remote branch deleted; commits not in main's history |
-| Rebase merge | `: gone]` after prune | Same as squash |
+| Squash merge | `git cherry -v main <branch>` | Commits often appear as `-` even if `--merged` misses them |
+| Rebase merge | `git cherry -v main <branch>` | Same pattern as squash merge |
+| Cherry-pick merge | `git cherry -v main <branch>` | Patch-equivalent commits appear as `-` |
 
 ## Protected Branches
 

--- a/skills/integration/SKILL.md
+++ b/skills/integration/SKILL.md
@@ -15,7 +15,7 @@ Creates PR, merges to main, and ensures proper Git workflow per repo CLAUDE.md.
 ## Flow
 
 1. **Commit** — [integration-commit](integration-commit/SKILL.md). Conventional message, issue reference.
-2. **PR** — [integration-pr](integration-pr/SKILL.md). Open PR, link issue, fill description.
+2. **PR** — [integration-pr](integration-pr/SKILL.md). Open PR, link issue, fill description, **assign the opener** (`gh pr create --assignee @me` or `gh pr edit` after create).
 3. **Review** — [code-review](../code-review/SKILL.md). Structured checklist on the diff (imports, headers, domain-neutral compliance wording, naming, security spot checks).
 4. **Merge** — [integration-merge](integration-merge/SKILL.md). Merge, resolve conflicts, squash if needed.
 

--- a/skills/integration/integration-pr/SKILL.md
+++ b/skills/integration/integration-pr/SKILL.md
@@ -19,7 +19,7 @@ For OpenClaw projects: [openclaw-security](../../openclaw-security/SKILL.md) mus
 ## Instructions
 
 1. Push branch: `git push -u origin <branch>`.
-2. Create PR: `gh pr create --base main --title "#NNN: type: description" --body "..."`.
+2. Create PR **with assignee**: `gh pr create --base main --assignee @me --title "#NNN: type: description" --body "..."` (substitute `@me` by the opener’s GitHub login if not the authenticated user). If your `gh pr create` does not support `--assignee`, create then run `gh pr edit <n> --add-assignee @me`.
 3. In body: Summary, Changes, link to issue (Closes #NNN).
 4. Add labels if repo uses them (`gh pr edit --add-label "..."`).
 
@@ -39,7 +39,7 @@ Closes #NNN
 ## Example
 
 ```bash
-gh pr create --base main --title "#8: feat: Phase 3 — remaining issue-workflow sub-skills" --body "## Summary
+gh pr create --base main --assignee @me --title "#8: feat: Phase 3 — remaining issue-workflow sub-skills" --body "## Summary
 Implements Phase 3...
 
 Closes #8"

--- a/skills/issue-workflow/SKILL.md
+++ b/skills/issue-workflow/SKILL.md
@@ -23,7 +23,8 @@ Orchestrates the GitHub issue lifecycle per [GitHub Issue Lifecycle](https://doc
 6. **Out-of-scope** — [issue-out-of-scope](issue-out-of-scope/SKILL.md). Define exclusions.
 7. **Estimate** — [issue-estimate](issue-estimate/SKILL.md). T-shirt size (XS–XL).
 8. **Metadata** — [issue-metadata](issue-metadata/SKILL.md). Tags, milestones, assignees (always assign the person who triggered the issue—directly or indirectly—so ownership and review are explicit).
-9. **Draft issue** — Combine into issue body with Goal, Tasks, Acceptance Criteria, Out of Scope, Estimate, Metadata.
+9. **Bulk EPIC + children with `gh` (optional)** — [issue-gh-bulk-scratch](issue-gh-bulk-scratch/SKILL.md). When creating many related issues at once: gitignored `tmp/EPIC-#.md` and `tmp/ISSUE-#.md` named **1-1** with GitHub issue numbers, and `--assignee @me` (or batch `gh issue edit`) so each item shows on the assignee’s list.
+10. **Draft issue** — Combine into issue body with Goal, Tasks, Acceptance Criteria, Out of Scope, Estimate, Metadata.
 
 ## Instructions
 
@@ -34,7 +35,8 @@ Orchestrates the GitHub issue lifecycle per [GitHub Issue Lifecycle](https://doc
 5. Run out-of-scope; list exclusions.
 6. Run estimate; add T-shirt size.
 7. Run metadata; add labels, milestone, and assignees (default: assign the trigger user per issue-metadata).
-8. Assemble final issue draft for `gh issue create` or paste into GitHub UI.
+8. If bulk-filing an EPIC and many sub-issues with `gh`, use [issue-gh-bulk-scratch](issue-gh-bulk-scratch/SKILL.md) for local 1-1 `tmp` names and self-assign.
+9. Assemble final issue draft for `gh issue create` or paste into GitHub UI.
 
 ## Output format
 
@@ -63,7 +65,7 @@ Labels: size:M, type:task — Milestone: (none) — Assignee: @trigger — Paren
 
 ## Integration
 
-Uses `gh` CLI: `gh issue list`, `gh issue view`, `gh issue create`. Ensure `gh auth login` if needed.
+Uses `gh` CLI: `gh issue list`, `gh issue view`, `gh issue create`. Ensure `gh auth login` if needed. For EPIC + multiple sub-issues with local scratch files, see [issue-gh-bulk-scratch](issue-gh-bulk-scratch/SKILL.md).
 
 ### Optional: V-model traceability
 

--- a/skills/issue-workflow/issue-gh-bulk-scratch/SKILL.md
+++ b/skills/issue-workflow/issue-gh-bulk-scratch/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: issue-gh-bulk-scratch
+description: Creates an EPIC and many GitHub issues with gh, keeps local gitignored tmp body files named 1-1 with issue numbers, and self-assigns. Use when batch-filing a portfolio/roadmap set from scratch files or renumbering after creation.
+---
+
+# GitHub bulk issues + local 1-1 scratch files
+
+## When to use
+
+- You are creating **one umbrella EPIC** and **several child issues** with `gh issue create` and want **local markdown copies** that stay in sync (filename = GitHub issue number).
+- You need **self-assignment** so every issue (EPIC and children) appears on the assignee’s list.
+- You are **renumbering** after creation when draft files were `ISSUE-1` … `ISSUE-n` (sequence) before you knew the real numbers.
+
+## Prerequisites
+
+- `gh auth login` (user who should own issues, so `@me` matches intended assignee)
+- `tmp/` in repo `.gitignore` for scratch (see repo CLAUDE.md)
+- [issue-metadata](../issue-metadata/SKILL.md): default assignee = trigger / operator via `--assignee @me`
+
+## Way of working
+
+1. **Draft bodies** in gitignored `tmp/` (repo root or `tmp/github/` if your repo standardizes that):
+   - **Option A (unknown numbers):** `tmp/EPIC-DRAFT.md` and `tmp/ISSUE-DRAFT-1.md` … `tmp/ISSUE-DRAFT-N.md` — import order = creation order, not the final issue number.
+   - **Option B (after creation):** one file per issue: `tmp/EPIC-<#>.md`, `tmp/ISSUE-<#>.md` (GitHub number in the name).
+
+2. **Create on GitHub** (PowerShell: parse number from the URL line `https://github.com/OWNER/REPO/issues/N` if `gh issue create` has no `--json number` in your `gh` version):
+   - EPIC first; optional `gh issue comment` on the EPIC listing children.
+   - For each child: `gh issue create --title "..." --body-file tmp/... --assignee @me` (or run **Assign** in step 4 in one pass).
+
+3. **Rename to 1-1 (required):** after you know the numbers, write final files as `tmp/EPIC-<N>.md` and `tmp/ISSUE-<N>.md` and delete the draft names. **The integer in the filename must equal the GitHub issue number.** Optional first line in each file:
+
+   ```markdown
+   > **Local scratch** for GitHub **#N** — [open issue](.../issues/N) · EPIC: [#PARENT](.../issues/PARENT)
+   ```
+
+4. **Self-assign (required for visibility on “my” list):** for EPIC and every child, either:
+   - pass `--assignee @me` on each `gh issue create`, or
+   - after creation: `gh issue edit <n> --add-assignee @me` for all `N` in one loop.
+
+   **PowerShell:** `@me` must be quoted or the shell treats `@` as splatting — use `--add-assignee '@me'` (or assign the login from `gh api user -q .login`).
+
+5. **Record mapping** in `tmp/GITHUB-REFS.md` (gitignored) or `tmp/GITHUB-REFS.md` + table: `Kind | # | URL | local file`.
+
+6. **Link children to EPIC:** `gh issue comment` on the EPIC with a checklist `- #16` …, and optionally a short comment on each child: `Part of portfolio EPIC #15`.
+
+## gh CLI (examples)
+
+```bash
+# Create with assignee
+gh issue create -t "Title" -F tmp/EPIC-DRAFT.md --assignee @me
+
+# Self-assign in batch (bash)
+for n in 15 16 17 18; do gh issue edit "$n" --add-assignee @me; done
+```
+
+## Integration
+
+- Composes with [issue-workflow](../SKILL.md) (duplicates, acceptance criteria) and [issue-metadata](../issue-metadata/SKILL.md) (assignee rules).
+- After issues exist, work follows the repo branch strategy ([plan-branch-strategy](../../plan-branch-strategy/SKILL.md), [plan](../../plan/SKILL.md)).
+
+## Anti-patterns
+
+- Committing `tmp/*` to git unless the project explicitly version-controls drafts.
+- Leaving assignees empty when the human requester is known — use `@me` or the requester’s login.
+- Keeping only `ISSUE-1` … `ISSUE-10` as final names when GitHub actually issued #16…#25 (breaks 1-1 reference).

--- a/skills/issue-workflow/issue-metadata/SKILL.md
+++ b/skills/issue-workflow/issue-metadata/SKILL.md
@@ -39,6 +39,16 @@ gh issue create --title "..." --body "..." --label "size:M" --label "type:task" 
 
 Use `--assignee <login>` when the trigger is another GitHub user. `gh api user -q .login` shows the authenticated account when you need to confirm `@me`.
 
+## Pull requests (same default)
+
+When opening a PR with `gh pr create`, apply the same ownership rule: pass **`--assignee @me`** (or the responsible human’s login) so the PR appears on their review list. If the flag is unavailable, run **`gh pr edit <n> --add-assignee @me`** immediately after create. Issues and PRs should not ship unassigned when the responsible person is known.
+
+Example:
+
+```bash
+gh pr create --base main --assignee @me --title "#42: fix: ..." --body "Closes #42"
+```
+
 ## Integration
 
 - Runs last in issue-workflow sequence.

--- a/skills/maintenance/maintenance-cleanup/SKILL.md
+++ b/skills/maintenance/maintenance-cleanup/SKILL.md
@@ -19,8 +19,11 @@ Post-merge hygiene: branch cleanup, worktree removal, GitHub Actions runs, tmp/ 
 For a full PR-merge checklist (merge, squash, rebase, `gone` remotes), see [branch-cleanup-after-pr](../../branch-cleanup-after-pr/SKILL.md).
 
 1. `git checkout main`, `git pull`
-2. `git branch -d <branch>` (or `-D` if squash-merged)
-3. `git fetch --prune` to remove stale remote-tracking refs
+2. `git fetch --prune` to remove stale remote-tracking refs
+3. Prefer `git branch -d <branch>`
+4. If `-d` fails with "not fully merged", run `git cherry -v main <branch>`:
+   - all `-` => functionally merged (safe to delete with `git branch -D <branch>`)
+   - any `+` => not merged, keep branch
 
 ### If branch is used by a worktree
 
@@ -28,11 +31,15 @@ If `git branch -D <branch>` fails with "cannot delete branch used by worktree", 
 
 ## GitHub Actions runs
 
-**on_prem_rag** (automated): After Python CI succeeds on `main`, the **Repository Cleanup** workflow runs [scripts/cleanup-github-actions.sh](https://github.com/pkuppens/on_prem_rag/blob/main/scripts/cleanup-github-actions.sh). Retention per workflow and branch:
+You can treat “obsolete” workflow runs as follows:
 
-- Keep the **latest passed** (GitHub `conclusion: success`) run as the canonical reference.
-- Keep **completed runs after** that pass (typically failures after the last green, for debugging).
-- **Delete** older passed runs and older failures/cancellations (superseded).
+1. **Runs from branches that are gone**: delete completed runs whose `head_branch` no longer exists in the repository.
+2. **Runs for workflows that no longer exist**: delete completed runs whose `workflow_id` is not present in the current workflow set.
+3. **Runs superseded by a later successful run**: for each workflow, keep the latest `conclusion: success` run, and delete other completed runs older than that latest success (superseded).
+
+### Repository examples
+
+**on_prem_rag** (automated): After Python CI succeeds on `main`, the **Repository Cleanup** workflow runs [scripts/cleanup-github-actions.sh](https://github.com/pkuppens/on_prem_rag/blob/main/scripts/cleanup-github-actions.sh). This implements (3) “superseded by later success” plus additional retention rules for debugging.
 
 Do **not** assume all failed runs are kept forever; only failures **after** the latest pass are retained.
 


### PR DESCRIPTION
## Summary

This change adds `issue-gh-bulk-scratch` for batch EPIC + child issues with `gh` and gitignored `tmp/` bodies named 1-1 with GitHub numbers. The issue-workflow orchestrator links it. `SKILL_TREE.md` registers §5.8 and updates the SKILL.md inventory count.

Assignee defaults are aligned: issues and PRs should be assigned so ownership is visible (`issue-metadata`, `integration`, `integration-pr`). Branch cleanup skills keep cross-links (`branch-cleanup-after-pr`, `maintenance-cleanup`).

Part of umbrella #26 (canonical skills).

Closes #67
Refs #26
