### PR TITLE
feat(skills): unify skill-creation with create-skill guidance

### DIFF
--- a/.cursor/commands/create-skill.md
+++ b/.cursor/commands/create-skill.md
@@ -1,0 +1,8 @@
+# create-skill
+
+Use the canonical meta-skill only (bundled Cursor `skills-cursor/create-skill` is not edited here):
+
+- Read [skills/_meta/skill-creation/SKILL.md](skills/_meta/skill-creation/SKILL.md) first.
+- Open [skills/_meta/skill-creation/reference.md](skills/_meta/skill-creation/reference.md) when you need patterns, phased workflow detail, extended anti-patterns, or the pre-merge checklist.
+
+`/create-skill` and `/skill-creation` resolve to the same instructions.

--- a/.cursor/commands/skill-creation.md
+++ b/.cursor/commands/skill-creation.md
@@ -1,0 +1,8 @@
+# skill-creation
+
+Use the canonical meta-skill only (bundled Cursor `skills-cursor/create-skill` is not edited here):
+
+- Read [skills/_meta/skill-creation/SKILL.md](skills/_meta/skill-creation/SKILL.md) first.
+- Open [skills/_meta/skill-creation/reference.md](skills/_meta/skill-creation/reference.md) when you need patterns, phased workflow detail, extended anti-patterns, or the pre-merge checklist.
+
+`/skill-creation` and `/create-skill` resolve to the same instructions.

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -29,9 +29,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install skills-ref (pinned)
         run: npm install -g skills-ref@0.1.5

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,10 @@ tmp/
 # causing broken clones. Documented setup lets each developer run symlink commands
 # after clone.
 .claude/
-.cursor/
+# Ignore local .cursor junk (skills symlink, machine config) but track shareable slash commands.
+.cursor/*
+!.cursor/commands/
+!.cursor/commands/**
 
 # To include them instead: use relative symlinks within the repo, e.g. from repo root:
 #   mkdir -p .cursor .claude

--- a/skills/_meta/skill-creation/SKILL.md
+++ b/skills/_meta/skill-creation/SKILL.md
@@ -1,95 +1,124 @@
 ---
 name: skill-creation
-description: Guides creation of new AI coding skills for Cursor, Claude, and Codex. Use when creating, writing, or authoring a new skill, or when asking about skill structure, SKILL.md format, or best practices. Enforces single responsibility, one-liner, progressive disclosure, and Claude skill structure.
+description: >-
+  Authors AI agent skills for Cursor, Claude Code, and similar tools using SKILL.md
+  structure and progressive disclosure. Use when creating, writing, or refactoring a
+  skill; when the user mentions SKILL.md, skill frontmatter, or skill best practices;
+  or when the user invokes slash commands that map here (includes create-skill).
+disable-model-invocation: true
 ---
 
-# Creating Skills
+# Skill creation (canonical)
 
-Guides creation of new skills per [Claude skill](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/best-practices).
+Guides authoring of reusable agent skills per [Claude skill best practices](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/best-practices). Cursor’s bundled `create-skill` under `skills-cursor/` is reference-only; **this folder is authoritative** for this repository’s skill tree (`skills/` junctioned from `~/.cursor/skills` when using the standard layout).
 
-## Required structure
+## When to read this skill
 
-Every skill needs a directory with `SKILL.md`:
+- New or rewritten skills, sub-skills, or meta-skills under `skills/`
+- Questions about YAML frontmatter, description wording, layout, or token budget
+- Ported workflows from Cursor-only docs into portable, Claude-aligned shape
+
+Deep patterns, anti-patterns, phased workflow, checklists, and optional project-facing trim live in [reference.md](reference.md).
+
+## Discovery (gather before drafting)
+
+Infer from context where possible; otherwise confirm:
+
+1. **Purpose / scope** — one capability per skill folder
+2. **Location** — personal (`~/.cursor/skills/` or synced `skills/`) vs repo-local `.cursor/skills/` for team-only overlays
+3. **Triggers** — when the agent should apply the skill automatically vs only when invoked
+4. **Domain facts** — only what models do not reliably know already
+5. **Output shapes** — templates, headings, or review formats required
+6. **Precedent** — existing skills in this tree to mirror
+
+**Verbatim user copy:** If the user supplies exact wording for the skill body, place it **verbatim** in `SKILL.md` (same words, same order). Do not paraphrase or wrap with extra headings unless they asked.
+
+**Clarification:** Prefer the AskQuestion tool when available; otherwise ask in chat (e.g. personal vs project path, whether to add `scripts/`).
+
+## Directory layout
 
 ```
 skill-name/
-├── SKILL.md              # Required
-├── reference.md          # Optional — loaded when needed
-└── examples.md          # Optional
+├── SKILL.md          # required
+├── reference.md      # optional (detail, patterns)
+├── examples.md       # optional
+└── scripts/          # optional (stable helpers; document run vs read)
 ```
 
-### YAML frontmatter
+**Do not** author new skills under `~/.cursor/skills-cursor/` (Cursor-managed). **Do** keep skills in this repo under `skills/<name>/` or in a project’s `.cursor/skills/<name>/` when the skill is repository-specific.
+
+## YAML frontmatter
 
 ```yaml
 ---
 name: skill-name
-description: What the skill does. Use when [trigger scenarios]. Third person, WHAT + WHEN.
+description: >-
+  What the skill does in third person; include trigger terms and "Use when …".
+  WHAT + WHEN; max 1024 chars.
+disable-model-invocation: true   # default: load when named; omit or false only for auto-invoke skills
 ---
 ```
 
-- **name:** Max 64 chars, lowercase letters, numbers, hyphens only
-- **description:** Max 1024 chars. Third person. Include trigger terms for discovery.
+| Field | Rule |
+|-------|------|
+| `name` | ≤64 chars; lowercase letters, digits, hyphens only |
+| `description` | Non-empty; third person; concrete triggers (not "helps with X" only) |
+
+## Writing descriptions
+
+Third person only. Prefer: *"Analyzes spreadsheets and suggests pivots. Use when working with `.xlsx` or tabular exports."*
+
+Avoid vague one-liners and first/second person ("I", "you can").
+
+Further examples and pitfalls: [reference.md](reference.md#description-snippets-and-failures).
 
 ## Principles
 
-### Single responsibility
-One skill = one capability. Compose for complex workflows.
-
-### One-liner
-Skill description + one-line summary per sub-skill. Optional 1–2 comment lines. No verbose explanations.
-
-### Progressive disclosure
-- Metadata (name, description) — always loaded
-- SKILL.md body — loaded when triggered
-- reference.md, examples.md — loaded as needed
-- Keep SKILL.md under 300 lines — create additional small skills when it would exceed.
+- **Single responsibility** — Compose multiple skills instead of one mega skill.
+- **One-liners** — Each section earns its tokens; subsection titles + tight bullets; defer essays to `reference.md`.
+- **Progressive disclosure** — Keep **`SKILL.md` ≤ ~300 lines**; split oversized content into `reference.md` / `examples.md` (prefer **single-level** links from `SKILL.md`).
+- **Self-improvement** — After errors or strong user feedback, update this meta-skill or the child skill accordingly.
 
 ### Degrees of freedom
 
 | Level | When | Example |
 |-------|------|---------|
-| High | Multiple valid approaches | Code review guidelines |
-| Medium | Preferred pattern, acceptable variation | Templates |
-| Low | Fragile, consistency critical | Exact scripts |
+| High | Several valid approaches | Code review judgement |
+| Medium | Preferred pattern, some slack | Report template |
+| Low | Fragile or compliance-sensitive steps | Scripted migration |
 
-## SKILL.md body template
+## SKILL.md body shape (minimal template)
+
+Use this scaffold when starting a new skill:
 
 ```markdown
 ---
 name: example-skill
-description: Does X. Use when [trigger].
+description: Does X in third person. Use when Y or Z.
 ---
 
-# Example Skill
+# Title
 
 ## When to use
-- Trigger scenario 1
-- Trigger scenario 2
+- …
 
 ## Instructions
-1. Step one
-2. Step two
-3. Step three
+1. …
 
-## Output format
-[Template if needed]
+## Output format (if needed)
+…
 
 ## Additional resources
-- See [reference.md](reference.md) for details
+- [reference.md](reference.md)
 ```
 
-## Anti-patterns
+## Architecture-aligned skills
 
-- Vague names: `helper`, `utils`, `tools`
-- First/second person in description
-- Explaining what the agent already knows
-- SKILL.md over 500 lines without split
-- Windows-style paths (`\`)
+For skills that encode architecture workflows, align with arc42 themes (sections 1–12): goals, constraints, context, solution strategy, building blocks, runtime, deployment, crosscutting concepts, decisions, quality, risks, glossary.
 
-## Arc42 alignment
+## Next steps for the agent
 
-For architecture-related skills, align with arc42 sections (1–12): goals, constraints, context, solution strategy, building blocks, runtime, deployment, crosscutting, decisions, quality, risks, glossary.
-
-## Self-improvement
-
-After using a skill that returns an error, or gets significant user feedback, consider: Did execution or user feedback suggest changes to the meta-skill or the new skill? Capture refinements for iteration.
+1. Resolve discovery items above (or infer safely).
+2. Draft `SKILL.md` respecting size and linking rules.
+3. Add `reference.md` / `examples.md` / `scripts/` only when justified.
+4. Run the checklist in [reference.md](reference.md#pre-merge-checklist).

--- a/skills/_meta/skill-creation/reference.md
+++ b/skills/_meta/skill-creation/reference.md
@@ -1,0 +1,223 @@
+# Skill authoring — reference
+
+Companion to [SKILL.md](SKILL.md). Load when patterns, examples, or checklists are needed.
+
+**Size:** Prefer keeping this file under ~500 lines; split into extra files (e.g. `reference-patterns.md`) if it grows.
+
+## Token discipline
+
+The context window is shared. Default assumption: the agent already knows general programming; add only non-obvious procedures, project facts, and fragile steps.
+
+Ask per paragraph: *Does the agent need this? Does it justify its token cost?*
+
+**Good (concise):**
+
+```markdown
+## Extract PDF text
+
+Use pdfplumber:
+
+\`\`\`python
+import pdfplumber
+with pdfplumber.open("file.pdf") as pdf:
+    text = pdf.pages[0].extract_text()
+\`\`\`
+```
+
+**Bad (verbose):** Long genre explanation of what PDFs are before naming a library.
+
+## Description snippets and failures
+
+```yaml
+# Strong
+description: Extract text and tables from PDFs, fill forms, merge documents. Use when working with PDFs, forms, or document extraction.
+
+# Strong
+description: Analyze Excel workbooks, pivot tables, and charts. Use when analyzing .xlsx files or tabular exports.
+
+# Weak
+description: Helps with documents
+```
+
+## Common patterns
+
+### Template pattern
+
+Give the agent a fixed output skeleton:
+
+```markdown
+## Report structure
+
+\`\`\`markdown
+# [Title]
+
+## Executive summary
+[One paragraph]
+
+## Findings
+- …
+
+## Recommendations
+1. …
+\`\`\`
+```
+
+### Examples pattern
+
+Show input → output pairs when format quality matters:
+
+```markdown
+## Commit message format
+
+**Example 1**  
+Input: Added user authentication with JWT  
+Output:
+\`\`\`
+feat(auth): implement JWT-based authentication
+
+Add login endpoint and token validation middleware
+\`\`\`
+```
+
+### Workflow pattern
+
+```markdown
+## Task checklist
+
+Task progress:
+- [ ] Step 1: …
+- [ ] Step 2: …
+
+**Step 1**  
+Run: \`python scripts/analyze_form.py input.pdf\`
+```
+
+### Conditional workflow pattern
+
+Branch on intent:
+
+```markdown
+1. **Creating new content?** → Creation workflow below.
+2. **Editing existing content?** → Editing workflow below.
+```
+
+### Feedback loop pattern
+
+For quality-critical work:
+
+```markdown
+1. Make edits.
+2. Run \`python scripts/validate.py output/\`.
+3. On failure: fix and repeat until clean.
+```
+
+## Utility scripts
+
+Prefer checked-in scripts when steps are brittle or must stay reproducible:
+
+- More reliable than ad-hoc generated code
+- Saves tokens if the skill points to execution instead of pasting logic
+- States clearly whether the agent should **execute** or **only read** the script as spec
+
+Example block for `SKILL.md` or here:
+
+```markdown
+**extract_fields.py** — list PDF form fields
+\`\`\`bash
+python scripts/extract_fields.py input.pdf > fields.json
+\`\`\`
+```
+
+## Anti-patterns
+
+| Issue | Prefer |
+|-------|--------|
+| Windows-only doc paths (`foo\\bar`) | POSIX-style \`scripts/helper.py\` in prose |
+| Tool salad ("use pypdf or pdfplumber or …") | One default tool + short escape hatch |
+| Deadlines baked into prose ("before August 2025 …") | "Current approach" vs collapsible deprecated |
+| Mixed vocabulary ("endpoint" / "route" / "URL" for same thing) | Pick one term |
+| Names like \`helpers\`, \`utils\`, \`tools\` | Specific verb-noun slug: \`deployment-release\`, \`code-review\` |
+
+## Phased workflow (implementation aid)
+
+When helping a human author a skill:
+
+1. **Discovery** — purpose, location (personal vs project), triggers, constraints, precedent skills.
+2. **Design** — folder name (\`skill-name\`), description draft, outline, whether \`reference.md\` /\`scripts/\` are needed.
+3. **Implement** — create tree, frontmatter, body, sibling files.
+4. **Verification** — run [Pre-merge checklist](#pre-merge-checklist); spot-check triggers with a teammate or second session.
+
+AskQuestion prompts (examples):
+
+- "Store under personal synced \`skills/\` or repo \`.cursor/skills/\` only?"
+- "Include executable scripts?"
+
+## Complete example layout
+
+```
+code-review/
+├── SKILL.md
+├── STANDARDS.md
+└── examples.md
+```
+
+**Sample `SKILL.md` excerpt:**
+
+```markdown
+---
+name: code-review
+description: Reviews changes for correctness, security, and maintainability per team standards. Use when reviewing pull requests, diffs, or when the user requests a code review.
+---
+
+# Code review
+
+## Quick start
+1. Correctness and edge cases
+2. Security (injection, authz, secrets)
+3. Readability and test coverage
+
+## Checklist
+- [ ] Logic and edge cases
+- [ ] Security issues
+- [ ] Style and structure
+- [ ] Tests adequately cover changes
+
+## Feedback levels
+- **Critical** — must fix before merge
+- **Suggestion** — should improve
+- **Nice to have** — optional
+
+## Additional resources
+- [STANDARDS.md](STANDARDS.md)
+- [examples.md](examples.md)
+```
+
+## Pre-merge checklist
+
+**Core**
+
+- [ ] \`description\` is third person with WHAT + WHEN and concrete trigger terms
+- [ ] \`name\` matches folder and naming rules
+- [ ] Primary \`SKILL.md\` stays within agreed budget (~≤300 lines); oversized parts moved here or to \`examples.md\`
+- [ ] Terminology is consistent throughout
+
+**Structure**
+
+- [ ] Links from \`SKILL.md\` to deeper files are **one level deep**
+- [ ] Workflows read as ordered, checkable steps
+- [ ] Time-sensitive lore avoided or isolated under deprecated/legacy headings
+
+**Scripts**
+
+- [ ] Scripts are documented (deps, inputs, outputs)
+- [ ] Explicit whether agents run or read them
+
+## Optional: trimmed project-facing copy
+
+For a **repository that only needs a subset** (e.g. public OSS without personal paths):
+
+1. Copy **When to use**, **Instructions**, and **Output format** sections into that repo’s \`.cursor/skills/<skill-name>/SKILL.md\`.
+2. Remove references to machine-specific junctions (\`~\`) and internal mono-repo paths unless the repo is private.
+3. Keep one link back to upstream docs or this \`skills/\` repo if governance requires a single authority.
+
+Compose with the main skill repo as source of truth; avoid long-lived divergence without versioning notes.


### PR DESCRIPTION
Merge Cursor-centric create-skill content into SKILL.md plus reference.md. Track .cursor/commands aliases and relax .gitignore for commands only.