### PR TITLE
chore(skills): improve validation diagnostics

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -41,15 +41,20 @@ jobs:
         run: |
           set -euo pipefail
           failed=0
+          failed_dirs=()
           while IFS= read -r -d '' skill_md; do
             dir=$(dirname "$skill_md")
             echo "::group::Validate $dir"
             if ! skills-ref validate "$dir"; then
               failed=1
+              failed_dirs+=("$dir")
+              echo "::error title=Skill validation failed::$dir"
             fi
             echo "::endgroup::"
           done < <(find skills -name 'SKILL.md' -print0)
           if [[ "$failed" -ne 0 ]]; then
             echo "One or more skills failed validation."
+            echo "Failed skill directories:"
+            printf '%s\n' "${failed_dirs[@]}"
             exit 1
           fi

--- a/skills/_meta/skill-creation/SKILL.md
+++ b/skills/_meta/skill-creation/SKILL.md
@@ -62,7 +62,7 @@ description: >-
 | `name` | ≤64 chars; lowercase letters, digits, hyphens only |
 | `description` | Non-empty; third person; concrete triggers (not "helps with X" only) |
 
-Only use frontmatter fields accepted by the Agent Skills validator for this repo.
+Keep frontmatter compatible with `skills-ref`; do not add tool-specific invocation fields.
 
 ## Writing descriptions
 


### PR DESCRIPTION
## Summary
- Ports only the useful validation diagnostics from `origin/task/skill-authoring-unify` onto a fresh branch from `main`.
- Keeps the skill-authoring frontmatter warning, but makes it specific to `skills-ref` compatibility.
- Leaves stale `origin/task/*` and `origin/cursor/*` branches to be deleted after this PR is merged.

## Branch review
- `origin/task/skill-authoring-unify` already had its main feature merged in PR #69; the remaining useful change was the CI diagnostics hunk.
- `origin/cursor/ci-branch-failures-e5a0` was merged in PR #72 and has no content diff from `main`.
- `origin/cursor/ci-branch-failures-ab60` and `origin/cursor/ci-failures-investigation-7c75` are closed alternative fixes and are superseded by this PR.

## Test plan
- [x] IDE lints: no issues reported for edited files.
- [x] `git diff --check`
- [ ] `skills-ref validate skills/_meta/skill-creation` could not be run locally because `npm`/`npx` are not available in this shell; CI should run the pinned validator.