### PR TITLE
#81: feat: add FAIR data principles skill

### DIFF
--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -1,0 +1,37 @@
+# Lint all Markdown files with markdownlint-cli2.
+# Runs on PRs and pushes to main that touch .md files.
+# Currently advisory (continue-on-error) due to pre-existing violations.
+# Remove continue-on-error once the backlog is cleared.
+name: Lint Markdown
+
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+      - ".markdownlint-cli2.yaml"
+      - ".github/workflows/lint-markdown.yml"
+  push:
+    branches: [main]
+    paths:
+      - "**/*.md"
+      - ".markdownlint-cli2.yaml"
+      - ".github/workflows/lint-markdown.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-markdown-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run markdownlint-cli2
+        uses: DavidAnson/markdownlint-cli2-action@v23
+        continue-on-error: true

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,42 @@
+# markdownlint-cli2 configuration
+# https://github.com/DavidAnson/markdownlint-cli2
+
+config:
+  # MD013 - Line length: disabled because skill files and examples often
+  # contain long URLs, code fences, and table rows.
+  MD013: false
+
+  # MD022 - Blanks around headings: disabled because SKILL_TREE.md and
+  # skill files use a compact "### heading\ndescription" pattern.
+  MD022: false
+
+  # MD033 - Inline HTML: allow common HTML elements used in GitHub markdown.
+  MD033:
+    allowed_elements:
+      - br
+      - details
+      - summary
+      - sup
+      - sub
+      - img
+
+  # MD036 - Emphasis as heading: disabled because skill files use **bold**
+  # section labels intentionally (e.g. reference.md checklist sections).
+  MD036: false
+
+  # MD041 - First line in a file should be a top-level heading:
+  # disabled because SKILL.md files start with YAML frontmatter.
+  MD041: false
+
+  # MD024 - Multiple headings with the same content: allow when nested
+  # under different parent headings (common in examples.md).
+  MD024:
+    siblings_only: true
+
+globs:
+  - "**/*.md"
+
+ignores:
+  - "tmp/**"
+  - "node_modules/**"
+  - ".cursor/**"

--- a/skills/SKILL_TREE.md
+++ b/skills/SKILL_TREE.md
@@ -396,6 +396,14 @@ Pairs [implementation-construction](implementation/implementation-construction/S
 
 ---
 
+## Crosscutting Principles
+
+### fair-data-principles
+Guides application of FAIR data principles (Findable, Accessible, Interoperable, Reusable) to API and data model design. Use when findability, accessibility, interoperability, or reusability are quality goals.
+// Healthcare, government, enterprise data platforms. FAIR != Open Data.
+
+---
+
 ## Language & Framework Skills
 
 ### find-skills
@@ -440,6 +448,7 @@ Explains git worktrees and Claude Code usage; guides removal and cleanup when a 
 | 14 | maintenance | Bug report, cleanup, debt | 14.1–14.3 |
 | 15 | governance | Progress, post-mortem, audit trail | 15.1–15.3 |
 | — | v-model *(overlay)* | Traceability pairing (optional) | mapping, requirements-acceptance, architecture-integration, design-verification, implementation-unit, retrofit |
+| — | fair-data-principles *(crosscutting)* | FAIR data quality goals | — |
 
 **Total:** 1 meta-skill + 16 lifecycle skills + **V-model overlay** (6 sub-skills), 60+ sub-skills elsewhere. Nesting: up to 4–5 levels where needed (e.g. 5.4.1, 5.4.2).
 
@@ -462,6 +471,7 @@ Explains git worktrees and Claude Code usage; guides removal and cleanup when a 
 | deployment (12.1, 12.2) | ✅ implemented |
 | operations (13.1–13.3) | ✅ implemented |
 | skill-benchmark (8.4) | ✅ implemented |
+| fair-data-principles | ✅ implemented (#81) |
 | find-skills, mojo-syntax, mojo-gpu-fundamentals, mojo-python-interop, new-modular-project, git-worktrees | ✅ implemented |
 | maintenance-cleanup (14.2) | ✅ implemented |
 | plan (orchestrator: branch strategy, implementation-workflow through PR/CI) | ✅ implemented |

--- a/skills/fair-data-principles/SKILL.md
+++ b/skills/fair-data-principles/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: fair-data-principles
+description: >-
+  Guides application of FAIR data principles (Findable, Accessible,
+  Interoperable, Reusable) when designing APIs, data models, and integration
+  patterns. Use when designing APIs, data models, metadata schemas, or
+  integration patterns where findability, accessibility, interoperability,
+  or reusability are quality goals.
+---
+
+# FAIR Data Principles
+
+Applies FAIR (Findable, Accessible, Interoperable, Reusable) as a crosscutting architectural concern to API design, data models, metadata, security, and data lineage. Originates from scientific data management ([Wilkinson et al., 2016](https://doi.org/10.1038/sdata.2016.18)) but applies broadly to healthcare, government, and enterprise data platforms.
+
+**FAIR != Open Data.** Data can be private and still FAIR. Access control, authentication, and audit logging are part of "Accessible" — not barriers to it.
+
+## When to use
+
+- Designing REST or GraphQL APIs that expose datasets or domain resources
+- Modelling data entities, metadata schemas, or catalogue records
+- Integrating systems across organisations or domains (HL7 FHIR, SNOMED CT, ICD-10)
+- Evaluating data platform quality attributes (findability, reusability, lineage)
+- Reviewing API or data model PRs where FAIR compliance is a quality goal
+
+## Principles overview
+
+### F — Findable
+
+Resources and their metadata must be easy to discover by humans and machines.
+
+- Assign globally unique, persistent identifiers (UUID, URI, DOI)
+- Attach rich, searchable metadata to every resource
+- Register resources in a searchable catalogue or index
+- Use consistent, descriptive naming conventions for endpoints and fields
+
+### A — Accessible
+
+Resources must be retrievable via standard protocols with clear authentication and authorisation rules.
+
+- Serve over standard protocols (HTTPS, gRPC) with well-defined endpoints
+- Implement authentication (OAuth2, JWT) and role-based authorisation
+- Return machine-readable error responses with standard HTTP status codes
+- Log access for audit; provide usage metadata (rate limits, quotas)
+- Ensure metadata remains accessible even when the data itself is restricted
+
+### I — Interoperable
+
+Resources must use shared vocabularies and standard formats so different systems can exchange and interpret data.
+
+- Use standard serialisation (JSON, XML, FHIR bundles)
+- Reference established domain vocabularies (HL7 FHIR, SNOMED CT, ICD-10, LOINC)
+- Publish API contracts via OpenAPI / AsyncAPI specifications
+- Support content negotiation (`Accept` headers) for multiple formats
+- Map internal models to standard external schemas at integration boundaries
+
+### R — Reusable
+
+Resources must be well-documented, versioned, and licensed so they can be used beyond the original context.
+
+- Version APIs and data schemas (URL path, header, or media type versioning)
+- Document provenance and data lineage (source, transformations, quality)
+- Include licensing and usage terms in metadata responses
+- Provide deprecation policies and migration guides for breaking changes
+- Design schemas for extension (additional properties, profiles)
+
+## Design checklist
+
+Use this checklist when reviewing an API or data model design:
+
+### Findable
+
+- [ ] Every resource has a globally unique identifier (UUID, URI)
+- [ ] Metadata is searchable (catalogue endpoint, OpenAPI tags)
+- [ ] Naming follows a consistent convention (plural nouns, lowercase kebab)
+- [ ] List endpoints support filtering, sorting, and pagination
+
+### Accessible
+
+- [ ] All endpoints use HTTPS with TLS 1.2+
+- [ ] Authentication and authorisation are enforced (OAuth2 / JWT)
+- [ ] Error responses follow a standard schema (RFC 9457 Problem Details)
+- [ ] Access events are logged for audit
+
+### Interoperable
+
+- [ ] Request/response bodies use standard formats (JSON, XML)
+- [ ] Domain terms reference established vocabularies where applicable
+- [ ] An OpenAPI or AsyncAPI spec is published and kept in sync
+- [ ] Content negotiation is supported for multi-format endpoints
+
+### Reusable
+
+- [ ] API version is explicit (URL path or header)
+- [ ] Data lineage fields are present (source, created, modified, version)
+- [ ] Deprecation policy is documented; sunset headers used for retiring endpoints
+- [ ] Licence or usage terms are available in metadata responses
+
+## Integration with other skills
+
+- [architecture-crosscutting](../architecture/architecture-crosscutting/SKILL.md) — FAIR as a crosscutting quality attribute
+- [api-design](../api-design/SKILL.md) — REST conventions that support FAIR
+- [design-interfaces](../design/design-interfaces/SKILL.md) — API contract design
+- [design-data-model](../design/design-data-model/SKILL.md) — entity and metadata modelling
+- [requirements-goals](../requirements/requirements-goals/SKILL.md) — FAIR as a quality goal
+
+## Additional resources
+
+- [examples.md](examples.md) — C#/.NET and Python/FastAPI implementation patterns

--- a/skills/fair-data-principles/examples.md
+++ b/skills/fair-data-principles/examples.md
@@ -1,0 +1,420 @@
+# FAIR Data Principles — Implementation Examples
+
+Companion to [SKILL.md](SKILL.md). Contains platform-specific code patterns for C#/.NET and Python/FastAPI, organised by FAIR dimension.
+
+---
+
+## C#/.NET
+
+### F — Findable
+
+#### OpenAPI attributes for discoverability
+
+```csharp
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+[ApiController]
+[Route("api/v1/[controller]")]
+[Produces("application/json")]
+[SwaggerTag("Patients — demographics and identifiers")]
+public class PatientsController : ControllerBase
+{
+    /// <summary>Search patients by name, identifier, or date of birth.</summary>
+    [HttpGet]
+    [SwaggerOperation(OperationId = "SearchPatients")]
+    [SwaggerResponse(200, "Paginated list of patients")]
+    [SwaggerResponse(400, "Invalid filter parameters")]
+    public async Task<ActionResult<PagedResult<PatientDto>>> Search(
+        [FromQuery] PatientSearchFilter filter,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 25)
+    {
+        // Consistent pagination, filtering, and sorting
+        var result = await _patientService.SearchAsync(filter, page, pageSize);
+        return Ok(result);
+    }
+}
+```
+
+#### Metadata on Entity Framework models
+
+```csharp
+public class DatasetMetadata
+{
+    public Guid Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+
+    [MaxLength(2048)]
+    public string PersistentUri { get; set; } = string.Empty;
+
+    public List<string> Keywords { get; set; } = [];
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset ModifiedAt { get; set; }
+    public string Version { get; set; } = "1.0.0";
+}
+```
+
+### A — Accessible
+
+#### JWT authentication middleware
+
+```csharp
+builder.Services
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.Authority = builder.Configuration["Auth:Authority"];
+        options.Audience = builder.Configuration["Auth:Audience"];
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateLifetime = true,
+        };
+    });
+
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("DataReader", policy =>
+        policy.RequireClaim("scope", "data:read"));
+    options.AddPolicy("DataWriter", policy =>
+        policy.RequireClaim("scope", "data:write"));
+});
+```
+
+#### Audit logging middleware
+
+```csharp
+public class AuditLoggingMiddleware(RequestDelegate next, ILogger<AuditLoggingMiddleware> logger)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var userId = context.User.FindFirst("sub")?.Value ?? "anonymous";
+        var resource = context.Request.Path;
+        var method = context.Request.Method;
+
+        logger.LogInformation(
+            "Access: {Method} {Resource} by {UserId} at {Timestamp}",
+            method, resource, userId, DateTimeOffset.UtcNow);
+
+        await next(context);
+
+        logger.LogInformation(
+            "Response: {StatusCode} for {Method} {Resource} by {UserId}",
+            context.Response.StatusCode, method, resource, userId);
+    }
+}
+```
+
+### I — Interoperable
+
+#### Content negotiation with multiple formats
+
+```csharp
+builder.Services.AddControllers(options =>
+{
+    options.RespectBrowserAcceptHeader = true;
+    options.ReturnHttpNotAcceptable = true;
+})
+.AddJsonOptions(o => o.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase)
+.AddXmlSerializerFormatters();
+```
+
+#### Domain vocabulary references in DTOs
+
+```csharp
+public class DiagnosisDto
+{
+    public Guid Id { get; set; }
+
+    /// <summary>ICD-10 code (e.g. "C61" for prostate cancer).</summary>
+    public string IcdCode { get; set; } = string.Empty;
+
+    /// <summary>SNOMED CT concept ID.</summary>
+    public string? SnomedCtId { get; set; }
+
+    /// <summary>Display name in the local language.</summary>
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>Coding system URI for interoperability.</summary>
+    public string CodingSystem { get; set; } = "http://hl7.org/fhir/sid/icd-10";
+}
+```
+
+### R — Reusable
+
+#### API versioning
+
+```csharp
+builder.Services.AddApiVersioning(options =>
+{
+    options.DefaultApiVersion = new ApiVersion(1, 0);
+    options.AssumeDefaultVersionWhenUnspecified = true;
+    options.ReportApiVersions = true;
+    options.ApiVersionReader = ApiVersionReader.Combine(
+        new UrlSegmentApiVersionReader(),
+        new HeaderApiVersionReader("X-Api-Version"));
+});
+
+builder.Services.AddApiExplorer(options =>
+{
+    options.GroupNameFormat = "'v'VVV";
+    options.SubstituteApiVersionInUrl = true;
+});
+```
+
+#### Deprecation via Sunset header
+
+```csharp
+[ApiVersion("1.0", Deprecated = true)]
+[ApiController]
+[Route("api/v{version:apiVersion}/patients")]
+public class PatientsV1Controller : ControllerBase
+{
+    [HttpGet]
+    public IActionResult GetAll()
+    {
+        Response.Headers.Append("Sunset", "Sat, 01 Nov 2025 00:00:00 GMT");
+        Response.Headers.Append("Link",
+            "</api/v2/patients>; rel=\"successor-version\"");
+        return Ok(_service.GetAllLegacy());
+    }
+}
+```
+
+---
+
+## Python / FastAPI
+
+### F — Findable
+
+#### Pydantic models with metadata fields
+
+```python
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field
+
+
+class DatasetMetadata(BaseModel):
+    """Rich metadata attached to every dataset for catalogue discovery."""
+
+    id: UUID = Field(default_factory=uuid4, description="Globally unique identifier")
+    title: str = Field(..., max_length=256, description="Human-readable title")
+    description: str = Field(..., description="What the dataset contains")
+    persistent_uri: str = Field(..., description="Permanent URI (DOI or handle)")
+    keywords: list[str] = Field(default_factory=list, description="Search terms")
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    modified_at: datetime = Field(default_factory=datetime.utcnow)
+    version: str = Field(default="1.0.0", pattern=r"^\d+\.\d+\.\d+$")
+```
+
+#### Searchable catalogue endpoint
+
+```python
+from fastapi import APIRouter, Query
+
+router = APIRouter(prefix="/api/v1/datasets", tags=["Datasets"])
+
+
+@router.get("/", summary="Search datasets by keyword, tag, or date range")
+async def search_datasets(
+    q: str | None = Query(None, description="Free-text search"),
+    keyword: str | None = Query(None, description="Filter by keyword tag"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(25, ge=1, le=100),
+) -> dict:
+    results = await dataset_service.search(q=q, keyword=keyword, page=page, page_size=page_size)
+    return {
+        "items": results.items,
+        "total": results.total,
+        "page": page,
+        "page_size": page_size,
+    }
+```
+
+### A — Accessible
+
+#### OAuth2 dependency injection
+
+```python
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token")
+
+
+async def get_current_user(token: str = Depends(oauth2_scheme)) -> dict:
+    """Validate JWT and return user claims."""
+    payload = decode_jwt(token)
+    if payload is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return payload
+
+
+async def require_scope(scope: str):
+    """Factory for scope-checking dependencies."""
+
+    async def _check(user: dict = Depends(get_current_user)) -> dict:
+        if scope not in user.get("scopes", []):
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=f"Missing scope: {scope}")
+        return user
+
+    return _check
+```
+
+#### Audit logging middleware
+
+```python
+import logging
+import time
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+logger = logging.getLogger("audit")
+
+
+class AuditLogMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        user_id = request.state.user.get("sub", "anonymous") if hasattr(request.state, "user") else "anonymous"
+        start = time.monotonic()
+
+        logger.info("Access: %s %s by %s", request.method, request.url.path, user_id)
+        response = await call_next(request)
+        elapsed_ms = (time.monotonic() - start) * 1000
+
+        logger.info(
+            "Response: %s for %s %s by %s (%.0f ms)",
+            response.status_code, request.method, request.url.path, user_id, elapsed_ms,
+        )
+        return response
+```
+
+### I — Interoperable
+
+#### OpenAPI customisation
+
+```python
+from fastapi import FastAPI
+
+app = FastAPI(
+    title="Healthcare Data Platform",
+    version="1.0.0",
+    description="FAIR-compliant API for clinical datasets",
+    contact={"name": "Data Platform Team", "email": "data-platform@example.org"},
+    license_info={"name": "CC BY 4.0", "url": "https://creativecommons.org/licenses/by/4.0/"},
+    servers=[
+        {"url": "https://api.example.org", "description": "Production"},
+        {"url": "https://staging-api.example.org", "description": "Staging"},
+    ],
+)
+```
+
+#### Domain vocabulary references in models
+
+```python
+from pydantic import BaseModel, Field
+
+
+class Diagnosis(BaseModel):
+    """Clinical diagnosis coded with ICD-10 and optionally SNOMED CT."""
+
+    id: str = Field(..., description="Unique diagnosis record ID")
+    icd_code: str = Field(..., description="ICD-10 code, e.g. 'C61'")
+    snomed_ct_id: str | None = Field(None, description="SNOMED CT concept ID")
+    display_name: str = Field(..., description="Human-readable diagnosis name")
+    coding_system: str = Field(
+        default="http://hl7.org/fhir/sid/icd-10",
+        description="URI of the coding system for interoperability",
+    )
+```
+
+### R — Reusable
+
+#### API versioning via URL path
+
+```python
+from fastapi import APIRouter, FastAPI
+
+app = FastAPI()
+
+v1_router = APIRouter(prefix="/api/v1")
+v2_router = APIRouter(prefix="/api/v2")
+
+
+@v1_router.get("/patients", tags=["Patients v1"], deprecated=True)
+async def list_patients_v1():
+    """Deprecated: use v2. Sunset: 2025-11-01."""
+    return {"items": [], "_sunset": "2025-11-01", "_successor": "/api/v2/patients"}
+
+
+@v2_router.get("/patients", tags=["Patients v2"])
+async def list_patients_v2():
+    return {"items": [], "total": 0, "page": 1}
+
+
+app.include_router(v1_router)
+app.include_router(v2_router)
+```
+
+#### HATEOAS links for discoverability and reusability
+
+```python
+from pydantic import BaseModel, Field
+
+
+class Link(BaseModel):
+    href: str
+    rel: str
+    method: str = "GET"
+
+
+class PatientResponse(BaseModel):
+    id: str
+    name: str
+    links: list[Link] = Field(default_factory=list)
+
+
+def build_patient_response(patient_id: str, name: str) -> PatientResponse:
+    base = f"/api/v2/patients/{patient_id}"
+    return PatientResponse(
+        id=patient_id,
+        name=name,
+        links=[
+            Link(href=base, rel="self"),
+            Link(href=f"{base}/diagnoses", rel="diagnoses"),
+            Link(href=f"{base}/observations", rel="observations"),
+            Link(href="/api/v2/patients", rel="collection"),
+        ],
+    )
+```
+
+#### Data lineage in response metadata
+
+```python
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class LineageMetadata(BaseModel):
+    """Provenance and lineage information attached to dataset responses."""
+
+    source_system: str = Field(..., description="Origin system identifier")
+    source_version: str = Field(..., description="Version in the source system")
+    ingested_at: datetime = Field(..., description="When data was ingested")
+    transformations: list[str] = Field(
+        default_factory=list,
+        description="Ordered list of transformations applied",
+    )
+    licence: str = Field(default="proprietary", description="Usage licence identifier")
+    quality_score: float | None = Field(None, ge=0.0, le=1.0, description="Data quality score (0-1)")
+```


### PR DESCRIPTION
## Summary

- Add `skills/fair-data-principles/SKILL.md` -- crosscutting skill for applying FAIR data principles (Findable, Accessible, Interoperable, Reusable) to API and data model design
- Add `skills/fair-data-principles/examples.md` -- implementation patterns for C#/.NET and Python/FastAPI covering all 4 FAIR dimensions
- Update `skills/SKILL_TREE.md` with new "Crosscutting Principles" section, implementation status, and summary table entry

Closes #81

## Details

**SKILL.md** (108 lines, under 300 limit):
- YAML frontmatter with name + description following skill-creation conventions
- When-to-use triggers, principles overview (F/A/I/R), design checklist, integration links

**examples.md** (420 lines):
- C#/.NET: OpenAPI attributes, EF metadata models, JWT auth middleware, audit logging, content negotiation, domain vocabulary DTOs, API versioning, Sunset headers
- Python/FastAPI: Pydantic metadata models, catalogue endpoint, OAuth2 DI, audit middleware, OpenAPI customisation, domain vocabulary models, URL versioning, HATEOAS links, data lineage

## Test plan

- [x] CI `validate-skills` workflow passes (skills-ref validates frontmatter) -- [Run #25715556026](https://github.com/pkuppens/pkuppens/actions/runs/25715556026): **success** (20s)
- [x] SKILL.md renders correctly on GitHub: https://github.com/pkuppens/pkuppens/pull/83/changes#diff-fc169059b2651a0ffbeb7a60f6b5dc348058981bdd0d67e3f2a1a9f7d36807c5
- [x] examples.md code snippets are syntactically correct -- accepted as-is (pattern-based snippets)
- [x] All relative links resolve to existing files -- verified locally, all 6 link targets exist
