### PR TITLE
#84: feat: add AI agent development skill with 7 sub-skills

### DIFF
--- a/skills/SKILL_TREE.md
+++ b/skills/SKILL_TREE.md
@@ -426,6 +426,34 @@ Explains git worktrees and Claude Code usage; guides removal and cleanup when a 
 
 ---
 
+## Domain Skills
+
+### ai-agent-development
+Guides implementation of AI agents: agent types, context/RAG, guardrails, swappable LLM providers, on-premises deployment, framework selection, and visual development. Use when designing, building, or reviewing AI agent systems in Python or C#.
+
+#### agent-types
+Classifies AI agent patterns: chat completion, tool-using, ReAct, A2A protocol, subagents, and multi-agent orchestration.
+
+#### agent-context
+Guides context management: RAG pipelines, knowledge graphs, embeddings, conversation memory, and context window strategies.
+
+#### agent-guardrails
+Guides guardrails: input/output validation, PII filtering, cost control, safety policies, and audit logging.
+
+#### agent-llm-providers
+Guides swappable LLM provider interfaces: open-source (Ollama, LlamaCPP) and closed-source (OpenAI, Gemini) via abstract base classes and factory patterns.
+
+#### agent-on-premises
+Guides on-premises deployment: local model serving, data sovereignty, air-gapped environments, GPU provisioning, and infrastructure patterns.
+
+#### agent-frameworks
+Compares agent frameworks: LangChain/LangGraph, Semantic Kernel, AutoGen, CrewAI. Guides framework selection based on language, agent pattern, and deployment constraints.
+
+#### agent-visual-dev
+Guides visual/GUI-based agent development with n8n, Flowise, and LangFlow. Covers low-code orchestration and on-premises self-hosting.
+
+---
+
 ## Summary: Skill Tree Overview
 
 | # | Skill | arc42 / Lifecycle | Sub-skills |
@@ -449,12 +477,13 @@ Explains git worktrees and Claude Code usage; guides removal and cleanup when a 
 | 15 | governance | Progress, post-mortem, audit trail | 15.1–15.3 |
 | — | v-model *(overlay)* | Traceability pairing (optional) | mapping, requirements-acceptance, architecture-integration, design-verification, implementation-unit, retrofit |
 | — | fair-data-principles *(crosscutting)* | FAIR data quality goals | — |
+| — | ai-agent-development *(domain)* | AI agent implementation | agent-types, agent-context, agent-guardrails, agent-llm-providers, agent-on-premises, agent-frameworks, agent-visual-dev |
 
-**Total:** 1 meta-skill + 16 lifecycle skills + **V-model overlay** (6 sub-skills), 60+ sub-skills elsewhere. Nesting: up to 4–5 levels where needed (e.g. 5.4.1, 5.4.2).
+**Total:** 1 meta-skill + 16 lifecycle skills + **V-model overlay** (6 sub-skills) + 1 domain skill (7 sub-skills), 60+ sub-skills elsewhere. Nesting: up to 4–5 levels where needed (e.g. 5.4.1, 5.4.2).
 
 ## Implementation Status
 
-*Inventory: **95** `SKILL.md` files under `pkuppens/skills/` (2026-05-01, #57, #59–#65, #67). See [audit-results.md](../docs/skills/audit-results.md) for how to regenerate the list.*
+*Inventory: **106** `SKILL.md` files under `pkuppens/skills/` (2026-05-12, #57, #59–#65, #67, #84). See [audit-results.md](../docs/skills/audit-results.md) for how to regenerate the list.*
 
 | Skill | Status |
 | skill-creation | ✅ implemented |
@@ -487,3 +516,4 @@ Explains git worktrees and Claude Code usage; guides removal and cleanup when a 
 | governance (15.1–15.3) | ✅ implemented (#61) |
 | requirements / design / implementation / validation / test **orchestrator** SKILL.md | ✅ nav + sub-skill links |
 | v-model overlay (#42) | ✅ implemented |
+| ai-agent-development + 7 sub-skills | ✅ implemented (#84) |

--- a/skills/ai-agent-development/SKILL.md
+++ b/skills/ai-agent-development/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: ai-agent-development
+description: >-
+  Guides implementation of AI agents: agent types, context/RAG, guardrails,
+  swappable LLM providers, on-premises deployment, framework selection, and
+  visual development. Use when designing, building, or reviewing AI agent
+  systems in Python or C#.
+---
+
+# AI Agent Development
+
+Covers the full design space for implementing AI agents — from simple chat completion wrappers to multi-agent orchestration with tool use, guardrails, and on-premises deployment. Provides framework-neutral patterns first, then maps them to concrete frameworks (LangChain/LangGraph, Semantic Kernel, AutoGen) and visual tools (n8n, Flowise).
+
+## When to use
+
+- Designing a new AI agent or multi-agent system
+- Adding tool use, RAG, or knowledge graph integration to an existing agent
+- Selecting between LangChain, Semantic Kernel, AutoGen, CrewAI, or rolling your own
+- Implementing swappable LLM backends (Ollama, LlamaCPP, OpenAI, Gemini)
+- Deploying agents on-premises with data sovereignty requirements
+- Adding guardrails, auditing, or cost control to agent pipelines
+- Evaluating visual/low-code agent builders (n8n, Flowise, LangFlow)
+- Reviewing agent code for architecture and security concerns
+
+## Sub-skills
+
+| Sub-skill | Concern | When to use |
+|-----------|---------|-------------|
+| [agent-types](agent-types/SKILL.md) | Agent taxonomy | Choosing the right agent pattern for the task |
+| [agent-context](agent-context/SKILL.md) | Context, RAG, knowledge graphs | Adding external knowledge to agents |
+| [agent-guardrails](agent-guardrails/SKILL.md) | Auditing, safety, guardrails | Securing agent input/output and tracking usage |
+| [agent-llm-providers](agent-llm-providers/SKILL.md) | Swappable LLM backends | Configuring open-source and closed-source models |
+| [agent-on-premises](agent-on-premises/SKILL.md) | On-premises deployment | Running agents locally with data sovereignty |
+| [agent-frameworks](agent-frameworks/SKILL.md) | Framework selection | Comparing and using agent frameworks |
+| [agent-visual-dev](agent-visual-dev/SKILL.md) | Visual/GUI development | Building agents with low-code tools |
+
+## Core design decisions
+
+Before building an agent, resolve these:
+
+1. **Agent pattern** — Is this a single-turn completion, a tool-using loop, a multi-agent system, or an A2A service? See [agent-types](agent-types/SKILL.md).
+2. **Context strategy** — Does the agent need RAG, a knowledge graph, long-term memory, or just the prompt? See [agent-context](agent-context/SKILL.md).
+3. **LLM backend** — Must it run on-premises? Which models? How do you swap providers? See [agent-llm-providers](agent-llm-providers/SKILL.md) and [agent-on-premises](agent-on-premises/SKILL.md).
+4. **Safety** — What guardrails, auditing, and cost controls are needed? See [agent-guardrails](agent-guardrails/SKILL.md).
+5. **Framework** — Build from scratch, use a framework, or use a visual tool? See [agent-frameworks](agent-frameworks/SKILL.md) and [agent-visual-dev](agent-visual-dev/SKILL.md).
+
+## Architecture pattern
+
+```
+User Input
+  │
+  ▼
+┌─────────────┐     ┌──────────────┐
+│  Guardrails │────▶│  Agent Core  │
+│  (input)    │     │  (reasoning) │
+└─────────────┘     └──────┬───────┘
+                           │
+              ┌────────────┼────────────┐
+              ▼            ▼            ▼
+        ┌──────────┐ ┌──────────┐ ┌──────────┐
+        │  Tools   │ │  RAG /   │ │  Sub-    │
+        │          │ │  Context │ │  agents  │
+        └──────────┘ └──────────┘ └──────────┘
+                           │
+                           ▼
+                    ┌─────────────┐
+                    │  LLM        │◀── Provider interface
+                    │  Provider   │    (Ollama / OpenAI / …)
+                    └─────────────┘
+                           │
+                           ▼
+                    ┌─────────────┐
+                    │  Guardrails │
+                    │  (output)   │
+                    └─────────────┘
+                           │
+                           ▼
+                      Agent Output
+```
+
+## Code examples
+
+See [examples.md](examples.md) for complete Python and C# implementations covering:
+
+- Minimal chat completion agent
+- Tool-using agent with provider abstraction
+- RAG-augmented agent
+- Multi-agent orchestration
+
+## Integration with other skills
+
+- [architecture-building-blocks](../architecture/architecture-building-blocks/SKILL.md) — agent as a building block in a larger system
+- [architecture-crosscutting](../architecture/architecture-crosscutting/SKILL.md) — guardrails and auditing as crosscutting concerns
+- [design-interfaces](../design/design-interfaces/SKILL.md) — LLM provider and tool interfaces
+- [api-design](../api-design/SKILL.md) — exposing agents as API endpoints
+- [fair-data-principles](../fair-data-principles/SKILL.md) — FAIR-aligned context and knowledge management
+
+## Additional resources
+
+- [reference.md](reference.md) — deep patterns, anti-patterns, framework comparison matrix
+- [examples.md](examples.md) — Python and C# code examples

--- a/skills/ai-agent-development/agent-context/SKILL.md
+++ b/skills/ai-agent-development/agent-context/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: agent-context
+description: >-
+  Guides context management for AI agents: RAG pipelines, knowledge graphs,
+  embeddings, conversation memory, and context window strategies. Use when
+  adding external knowledge to agents or managing long conversations.
+---
+
+# Agent Context
+
+Patterns for providing agents with knowledge beyond the LLM's training data. Covers retrieval-augmented generation (RAG), knowledge graphs, embedding strategies, conversation memory, and context window management.
+
+## When to use
+
+- Building a RAG pipeline (document ingestion → chunking → embedding → retrieval → generation)
+- Integrating a knowledge graph as a context source
+- Managing conversation history that exceeds the context window
+- Choosing between vector search, BM25, and hybrid retrieval
+- Designing the chunking strategy for a document corpus
+
+## RAG pipeline
+
+```
+Documents → Ingestion → Chunking → Embedding → Vector Store
+                                                     │
+User query → Embedding → Similarity search ──────────┘
+                                  │
+                           Retrieved chunks
+                                  │
+                    System prompt + chunks + query → LLM → Response
+```
+
+### Ingestion
+
+- Support multiple file types: PDF, DOCX, Markdown, HTML, plain text
+- Extract metadata (title, author, date, source URL) for filtering
+- Track document versions for re-indexing
+
+### Chunking strategies
+
+| Strategy | Description | Best for |
+|----------|-------------|----------|
+| Fixed-size | Split by character/token count with overlap | General purpose, predictable chunk sizes |
+| Recursive | Split by structure (paragraphs, sentences, words) with fallback | Structured documents |
+| Semantic | Group by topic similarity using embeddings | Topic-coherent retrieval |
+| Document-aware | Respect headings, sections, tables | Technical documentation |
+
+- **Overlap** — 10-20% overlap between chunks prevents splitting mid-sentence
+- **Chunk size** — 256-1024 tokens is typical; smaller for precision, larger for context
+
+### Embedding models
+
+| Model | Dimensions | On-premises | Notes |
+|-------|-----------|-------------|-------|
+| `all-MiniLM-L6-v2` | 384 | Yes (sentence-transformers) | Fast, good baseline |
+| `nomic-embed-text` | 768 | Yes (Ollama) | Strong open-source option |
+| `text-embedding-3-small` | 1536 | No (OpenAI API) | High quality, cloud-only |
+| `text-embedding-3-large` | 3072 | No (OpenAI API) | Highest quality, cloud-only |
+
+### Retrieval strategies
+
+| Strategy | Mechanism | Strengths |
+|----------|-----------|-----------|
+| Dense (vector) | Cosine similarity on embeddings | Semantic matching |
+| Sparse (BM25) | Term frequency–inverse document frequency | Exact keyword matches |
+| Hybrid | Weighted combination of dense + sparse | Best of both approaches |
+| Re-ranking | Score initial results with a cross-encoder | Higher precision at retrieval time |
+
+## Knowledge graphs
+
+Use a knowledge graph when relationships between entities matter more than text similarity.
+
+- **Triple store** — (subject, predicate, object) facts; query with SPARQL or Cypher
+- **Graph RAG** — combine graph traversal with text retrieval for relationship-aware answers
+- **Entity extraction** — extract entities from documents and link them to the graph
+- **Tools:** Neo4j, Amazon Neptune, Apache Jena, or in-memory graphs (NetworkX)
+
+### When to prefer a knowledge graph over vector search
+
+- Domain has well-defined entities and relationships (medical ontologies, org charts)
+- Questions involve multi-hop reasoning ("Who reports to the manager of project X?")
+- Factual accuracy matters more than semantic similarity
+- Data changes frequently and must be updated without re-embedding
+
+## Conversation memory
+
+| Pattern | Description | Use when |
+|---------|-------------|----------|
+| Full history | Include all messages in prompt | Short conversations, small context windows |
+| Sliding window | Keep last N messages | Long conversations with recent-context focus |
+| Summarisation | Periodically summarise older messages | Very long sessions, memory-constrained |
+| Semantic memory | Store and retrieve relevant past messages by similarity | Agents that recall across sessions |
+
+## Context window management
+
+- **Token counting** — count tokens before sending to avoid truncation (use `tiktoken` for OpenAI, model-specific tokenisers for others)
+- **Priority ordering** — system prompt > retrieved context > conversation history > user message
+- **Truncation strategy** — drop oldest messages first; never truncate the system prompt or current user message
+- **Compression** — summarise retrieved documents before injection to fit more sources
+
+## Integration with other skills
+
+- [agent-types](../agent-types/SKILL.md) — RAG agent pattern
+- [agent-llm-providers](../agent-llm-providers/SKILL.md) — embedding model selection per provider
+- [fair-data-principles](../../fair-data-principles/SKILL.md) — FAIR-aligned metadata for retrieved documents
+- [design-data-model](../../design/design-data-model/SKILL.md) — document and chunk data models

--- a/skills/ai-agent-development/agent-frameworks/SKILL.md
+++ b/skills/ai-agent-development/agent-frameworks/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: agent-frameworks
+description: >-
+  Compares AI agent frameworks: LangChain/LangGraph, Semantic Kernel, AutoGen,
+  CrewAI. Guides framework selection based on language, agent pattern, and
+  deployment constraints. Use when choosing or evaluating an agent framework.
+---
+
+# Agent Frameworks
+
+Comparison and guidance for AI agent frameworks. Covers Python-first frameworks (LangChain, LangGraph, CrewAI, AutoGen) and C#-first frameworks (Semantic Kernel, AutoGen for .NET). Helps select the right framework based on requirements.
+
+## When to use
+
+- Evaluating frameworks for a new agent project
+- Migrating between frameworks
+- Comparing LangChain vs Semantic Kernel vs rolling your own
+- Deciding between code-first and visual agent builders
+
+## Framework comparison
+
+| Framework | Language | Agent pattern | Strengths | Weaknesses |
+|-----------|----------|---------------|-----------|------------|
+| **LangChain** | Python, JS | Chains, agents, tools | Largest ecosystem, most integrations | Frequent breaking changes, abstraction overhead |
+| **LangGraph** | Python, JS | Graph-based agent orchestration | Explicit state machines, checkpointing, human-in-the-loop | Steeper learning curve than plain LangChain |
+| **Semantic Kernel** | C#, Python, Java | Plugins, planners, agents | Microsoft ecosystem, Azure integration, enterprise-ready | Smaller community than LangChain |
+| **AutoGen** | Python, C# | Multi-agent conversations | Strong multi-agent patterns, Microsoft backing | API still evolving (v0.4+) |
+| **CrewAI** | Python | Role-based agent teams | Simple multi-agent setup, task delegation | Less flexible than LangGraph for complex flows |
+| **Haystack** | Python | Pipeline-based RAG and agents | Clean pipeline abstraction, production-focused | Smaller agent feature set than LangChain |
+| **Custom** | Any | Any | Full control, no dependency overhead | Must build everything from scratch |
+
+## When to use which
+
+### LangChain / LangGraph (Python)
+
+Choose when:
+- Python is the primary language
+- You need extensive integrations (100+ vector stores, LLM providers, tools)
+- Building graph-based agent workflows with state management
+- Human-in-the-loop approval patterns are needed
+
+```python
+from langgraph.graph import StateGraph, MessagesState, START, END
+from langchain_openai import ChatOpenAI
+
+def agent_node(state: MessagesState):
+    llm = ChatOpenAI(model="gpt-4o")
+    response = llm.invoke(state["messages"])
+    return {"messages": [response]}
+
+graph = StateGraph(MessagesState)
+graph.add_node("agent", agent_node)
+graph.add_edge(START, "agent")
+graph.add_edge("agent", END)
+app = graph.compile()
+```
+
+### Semantic Kernel (C#)
+
+Choose when:
+- C# / .NET is the primary language
+- Azure OpenAI is the LLM backend
+- Enterprise requirements (compliance, audit, RBAC)
+- Integrating with existing .NET microservices
+
+```csharp
+var kernel = Kernel.CreateBuilder()
+    .AddAzureOpenAIChatCompletion("gpt-4o", endpoint, apiKey)
+    .Build();
+
+kernel.Plugins.AddFromType<TimePlugin>();
+kernel.Plugins.AddFromType<SearchPlugin>();
+
+var agent = new ChatCompletionAgent
+{
+    Kernel = kernel,
+    Name = "Assistant",
+    Instructions = "You are a helpful assistant."
+};
+```
+
+### AutoGen (Python / C#)
+
+Choose when:
+- Multi-agent conversation is the primary pattern
+- Agents need to debate, review, or collaborate
+- You want built-in conversation management
+
+### CrewAI (Python)
+
+Choose when:
+- Role-based agent teams (researcher, writer, reviewer)
+- Task delegation with simple sequential or parallel workflows
+- Rapid prototyping of multi-agent systems
+
+### Custom / no framework
+
+Choose when:
+- Simple single-agent with a few tools
+- Maximum control over the agent loop
+- Minimal dependencies are a requirement
+- The framework abstraction adds more complexity than it removes
+
+## Framework selection checklist
+
+- [ ] **Language** — Does the framework support your primary language?
+- [ ] **Agent pattern** — Does it match the agent type you need (single, multi-agent, graph)?
+- [ ] **LLM providers** — Does it support your required providers (cloud + on-prem)?
+- [ ] **Tool ecosystem** — Are the integrations you need available (vector stores, APIs)?
+- [ ] **Production readiness** — Is it stable enough for production (versioning, support)?
+- [ ] **On-premises** — Can it run without cloud dependencies?
+- [ ] **Learning curve** — Can your team adopt it within the project timeline?
+
+## Anti-patterns
+
+- **Framework lock-in** — coupling business logic tightly to framework abstractions; keep core agent logic framework-independent where possible
+- **Abstraction tax** — using a framework for a 20-line agent loop; the framework overhead outweighs the benefit
+- **Version chasing** — upgrading LangChain every week; pin versions and upgrade deliberately
+- **One framework for everything** — using LangChain for a simple completion wrapper that needs 3 lines of `openai` SDK
+
+## Integration with other skills
+
+- [agent-types](../agent-types/SKILL.md) — framework capabilities per agent pattern
+- [agent-llm-providers](../agent-llm-providers/SKILL.md) — provider support per framework
+- [agent-visual-dev](../agent-visual-dev/SKILL.md) — visual alternatives to code-first frameworks
+- [ideation-reuse-check](../../ideation/ideation-reuse-check/SKILL.md) — checking if a framework already solves the problem

--- a/skills/ai-agent-development/agent-guardrails/SKILL.md
+++ b/skills/ai-agent-development/agent-guardrails/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: agent-guardrails
+description: >-
+  Guides implementation of AI agent guardrails: input/output validation,
+  PII filtering, cost control, safety policies, and audit logging. Use when
+  securing agent pipelines or adding compliance and observability.
+---
+
+# Agent Guardrails
+
+Patterns for securing AI agent input and output, controlling costs, protecting privacy, and maintaining audit trails. Guardrails wrap the agent core — they do not replace good prompt engineering.
+
+## When to use
+
+- Adding input validation or output filtering to an agent
+- Implementing PII detection and redaction
+- Setting up cost controls (token budgets, rate limits)
+- Adding audit logging for compliance or debugging
+- Reviewing agent security posture
+
+## Guardrail architecture
+
+Guardrails apply at two points in the agent pipeline:
+
+```
+User Input → [Input Guardrails] → Agent Core → [Output Guardrails] → User Output
+                                       │
+                                  [Audit Log]
+```
+
+### Input guardrails
+
+| Guardrail | Purpose | Implementation |
+|-----------|---------|----------------|
+| Prompt injection detection | Block attempts to override system instructions | Pattern matching, classifier model, or dedicated guardrail LLM |
+| Input sanitisation | Strip dangerous content (scripts, SQL) | Regex/allowlist filtering |
+| Topic restriction | Reject off-topic or prohibited queries | Classifier or keyword filter |
+| Rate limiting | Prevent abuse and control costs | Token bucket, sliding window |
+| Authentication | Verify caller identity | OAuth2, API key, JWT validation |
+
+### Output guardrails
+
+| Guardrail | Purpose | Implementation |
+|-----------|---------|----------------|
+| PII filtering | Redact personal data from responses | Named entity recognition (spaCy, Presidio) |
+| Content policy | Block harmful, biased, or inappropriate output | Content classifier, keyword blocklist |
+| Hallucination detection | Flag unsupported claims | Cross-reference with retrieved sources |
+| Format validation | Ensure structured output matches expected schema | JSON schema validation, Pydantic parsing |
+| Citation enforcement | Require source references in responses | Post-processing check against retrieved docs |
+
+## PII filtering
+
+Use Microsoft Presidio or spaCy NER for on-premises PII detection:
+
+- **Detection** — identify PII entities (names, emails, phone numbers, SSNs, medical IDs)
+- **Redaction** — replace with placeholders (`[PERSON]`, `[EMAIL]`)
+- **Pseudonymisation** — replace with consistent fake values for testing
+- **Audit** — log what was redacted (type, position) without logging the actual PII
+
+Healthcare-specific: filter patient identifiers, medical record numbers, and clinical data per HIPAA/GDPR.
+
+## Cost control
+
+- **Token budgets** — set max input + output tokens per request and per session
+- **Model routing** — use cheaper models for simple tasks, expensive models for complex ones
+- **Caching** — cache identical or semantically similar queries to avoid redundant LLM calls
+- **Circuit breaker** — disable the agent if spend exceeds a threshold
+
+```python
+class CostGuard:
+    def __init__(self, max_tokens_per_request: int, max_cost_per_day: float):
+        self.max_tokens_per_request = max_tokens_per_request
+        self.max_cost_per_day = max_cost_per_day
+        self.daily_cost = 0.0
+
+    def check(self, estimated_tokens: int, cost_per_token: float) -> bool:
+        estimated_cost = estimated_tokens * cost_per_token
+        if estimated_tokens > self.max_tokens_per_request:
+            return False
+        if self.daily_cost + estimated_cost > self.max_cost_per_day:
+            return False
+        return True
+```
+
+## Audit logging
+
+Every agent interaction should produce an audit record:
+
+| Field | Description |
+|-------|-------------|
+| `request_id` | Unique identifier for the interaction |
+| `timestamp` | ISO 8601 timestamp |
+| `user_id` | Authenticated caller identity |
+| `model` | LLM model used |
+| `input_tokens` | Token count for the input |
+| `output_tokens` | Token count for the output |
+| `tools_called` | List of tools invoked with arguments (redacted) |
+| `guardrails_triggered` | Which guardrails fired and their action (block, redact, warn) |
+| `latency_ms` | End-to-end response time |
+| `cost` | Estimated cost of the interaction |
+
+- Store audit logs separately from application logs
+- Never log raw user input or LLM output in production (PII risk) — log hashes or redacted versions
+- Retention policy aligned with compliance requirements (GDPR: purpose-limited, HIPAA: 6 years)
+
+## Frameworks and libraries
+
+| Tool | Language | Scope |
+|------|----------|-------|
+| Guardrails AI | Python | Input/output validation with RAIL specs |
+| NeMo Guardrails (NVIDIA) | Python | Programmable guardrails for LLM apps |
+| Microsoft Presidio | Python | PII detection and anonymisation |
+| LangChain output parsers | Python | Structured output validation |
+| Semantic Kernel filters | C# | Pre/post-processing in the SK pipeline |
+
+## Integration with other skills
+
+- [agent-types](../agent-types/SKILL.md) — guardrails apply to all agent types
+- [agent-on-premises](../agent-on-premises/SKILL.md) — on-prem PII filtering avoids sending data to cloud
+- [operations-audit](../../operations/operations-audit/SKILL.md) — audit trail integration
+- [architecture-crosscutting](../../architecture/architecture-crosscutting/SKILL.md) — guardrails as crosscutting concern

--- a/skills/ai-agent-development/agent-llm-providers/SKILL.md
+++ b/skills/ai-agent-development/agent-llm-providers/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: agent-llm-providers
+description: >-
+  Guides implementation of swappable LLM provider interfaces for AI agents.
+  Covers open-source (Ollama, LlamaCPP) and closed-source (OpenAI, Gemini)
+  backends via abstract base classes and factory patterns. Use when designing
+  configurable or multi-provider agent systems.
+---
+
+# Agent LLM Providers
+
+Patterns for abstracting LLM backends behind a common interface so agents can swap between providers without changing application code. Covers provider abstraction, factory pattern, configuration, and the trade-offs of each backend.
+
+## When to use
+
+- Designing a new agent system that must support multiple LLM providers
+- Adding a new provider to an existing multi-provider system
+- Switching from cloud APIs to on-premises models (or vice versa)
+- Comparing providers for cost, quality, or latency
+
+## Provider abstraction
+
+Define an abstract interface that all providers implement:
+
+```python
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+@dataclass
+class LLMResponse:
+    content: str
+    model: str
+    input_tokens: int
+    output_tokens: int
+
+class BaseLLMProvider(ABC):
+    @abstractmethod
+    async def complete(
+        self,
+        messages: list[dict[str, str]],
+        temperature: float = 0.7,
+        max_tokens: int = 1024,
+    ) -> LLMResponse:
+        ...
+
+    @abstractmethod
+    async def complete_with_tools(
+        self,
+        messages: list[dict[str, str]],
+        tools: list[dict],
+        temperature: float = 0.7,
+    ) -> LLMResponse:
+        ...
+```
+
+### Factory pattern
+
+```python
+def create_llm_provider(backend: str, **kwargs) -> BaseLLMProvider:
+    providers = {
+        "ollama": OllamaProvider,
+        "openai": OpenAIProvider,
+        "gemini": GeminiProvider,
+        "llamacpp": LlamaCPPProvider,
+    }
+    if backend not in providers:
+        raise ValueError(f"Unknown backend: {backend}. Available: {list(providers)}")
+    return providers[backend](**kwargs)
+```
+
+### Configuration via environment
+
+```bash
+LLM_BACKEND=ollama
+LLM_MODEL=llama3.2
+LLM_BASE_URL=http://localhost:11434
+LLM_API_KEY=          # empty for local providers
+LLM_TEMPERATURE=0.7
+LLM_MAX_TOKENS=2048
+```
+
+## Provider comparison
+
+### Open-source (on-premises capable)
+
+| Provider | Interface | Models | GPU required | Strengths |
+|----------|-----------|--------|-------------|-----------|
+| Ollama | REST API (OpenAI-compatible) | Llama, Mistral, Gemma, Phi, Qwen | Recommended | Easy setup, model management, OpenAI-compatible API |
+| llama.cpp | C++ library, Python bindings | GGUF format models | Optional (CPU possible) | Lightweight, quantisation support, runs on CPU |
+| vLLM | REST API (OpenAI-compatible) | HuggingFace models | Yes | High throughput, production-grade serving |
+| TGI (HuggingFace) | REST API | HuggingFace models | Yes | HuggingFace ecosystem integration |
+
+### Closed-source (cloud APIs)
+
+| Provider | SDK | Key models | Strengths |
+|----------|-----|------------|-----------|
+| OpenAI | `openai` Python, C# SDK | GPT-4o, GPT-4o-mini, o3 | Widest tool-calling support, mature SDK |
+| Google Gemini | `google-genai` Python SDK | Gemini 2.5 Pro/Flash | Multimodal, large context window (1M tokens) |
+| Anthropic | `anthropic` Python SDK | Claude Sonnet/Opus | Strong reasoning, extended thinking |
+| Azure OpenAI | `openai` with Azure config | Same as OpenAI | Enterprise compliance, VNet integration |
+
+## Design guidelines
+
+- **OpenAI-compatible API as baseline** — Ollama, vLLM, and LiteLLM all expose OpenAI-compatible endpoints; design your provider interface around this
+- **Model-specific capabilities** — not all models support tool calling, vision, or structured output; query capabilities at init or config time
+- **Streaming** — implement both streaming and non-streaming completion; use streaming for interactive UIs
+- **Retry with backoff** — cloud APIs rate-limit; implement exponential backoff with jitter
+- **Fallback chain** — configure a primary and fallback provider for reliability (e.g. GPT-4o → Ollama local)
+- **Token counting** — each provider tokenises differently; use provider-specific tokenisers for accurate counting
+
+## C# provider abstraction (Semantic Kernel)
+
+Semantic Kernel provides built-in provider abstraction:
+
+```csharp
+// Swap providers by changing the service registration
+var builder = Kernel.CreateBuilder();
+
+// OpenAI
+builder.AddOpenAIChatCompletion("gpt-4o", apiKey);
+
+// Azure OpenAI
+builder.AddAzureOpenAIChatCompletion("gpt-4o", endpoint, apiKey);
+
+// Ollama (OpenAI-compatible endpoint)
+builder.AddOpenAIChatCompletion("llama3.2", apiKey: null,
+    httpClient: new HttpClient { BaseAddress = new Uri("http://localhost:11434/v1") });
+```
+
+## Integration with other skills
+
+- [agent-types](../agent-types/SKILL.md) — providers power all agent types
+- [agent-on-premises](../agent-on-premises/SKILL.md) — on-prem model selection and serving
+- [agent-guardrails](../agent-guardrails/SKILL.md) — cost control per provider
+- [design-interfaces](../../design/design-interfaces/SKILL.md) — provider interface design patterns

--- a/skills/ai-agent-development/agent-on-premises/SKILL.md
+++ b/skills/ai-agent-development/agent-on-premises/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: agent-on-premises
+description: >-
+  Guides on-premises deployment of AI agents: local model serving, data
+  sovereignty, air-gapped environments, GPU provisioning, and infrastructure
+  patterns. Use when agents must run locally without sending data to cloud APIs.
+---
+
+# Agent On-Premises
+
+Patterns for deploying AI agents entirely on-premises — no data leaves the local network. Covers model serving, GPU provisioning, infrastructure, and the trade-offs versus cloud deployment.
+
+## When to use
+
+- Data sovereignty or regulatory requirements prohibit cloud API usage (GDPR, HIPAA, government)
+- Air-gapped or restricted network environments
+- Sensitive data (medical records, financial data, classified information) must not leave the premises
+- Cost optimisation for high-volume inference (own hardware vs pay-per-token)
+- Low-latency requirements where cloud round-trips are unacceptable
+
+## Architecture
+
+```
+On-Premises Network
+┌──────────────────────────────────────────────────┐
+│                                                  │
+│  ┌──────────┐    ┌─────────────┐   ┌──────────┐ │
+│  │  Agent    │───▶│  Model      │   │  Vector  │ │
+│  │  App      │    │  Server     │   │  Store   │ │
+│  │ (FastAPI) │    │ (Ollama /   │   │ (Chroma /│ │
+│  └──────────┘    │  vLLM)      │   │  Qdrant) │ │
+│       │          └─────────────┘   └──────────┘ │
+│       │                │                  │      │
+│       └────────────────┼──────────────────┘      │
+│                        │                         │
+│                  ┌─────┴─────┐                   │
+│                  │   GPU(s)  │                   │
+│                  └───────────┘                   │
+└──────────────────────────────────────────────────┘
+```
+
+## Model serving options
+
+| Server | Setup complexity | Production-ready | GPU support | Quantisation |
+|--------|-----------------|-----------------|-------------|-------------|
+| Ollama | Low (single binary) | Development / small teams | CUDA, ROCm, Metal | GGUF (Q4, Q5, Q8) |
+| vLLM | Medium (Python) | Yes (high throughput) | CUDA | AWQ, GPTQ, FP8 |
+| TGI | Medium (Docker) | Yes (HuggingFace) | CUDA | GPTQ, AWQ, EETQ |
+| llama.cpp | Low (C++ binary) | Development | CUDA, Metal, Vulkan, CPU | GGUF (extensive) |
+| LocalAI | Medium (Docker) | Community | CUDA, CPU | GGUF, GPTQ |
+
+## GPU provisioning
+
+### Minimum GPU memory by model size
+
+| Model parameters | Min GPU VRAM (FP16) | Min GPU VRAM (Q4) | Example GPU |
+|-----------------|--------------------|--------------------|-------------|
+| 1-3B | 4 GB | 2 GB | RTX 3060 (12 GB) |
+| 7-8B | 16 GB | 4-6 GB | RTX 4070 (12 GB) |
+| 13B | 28 GB | 8-10 GB | RTX 4090 (24 GB) |
+| 30-34B | 68 GB | 20-24 GB | A100 (40 GB) or 2x RTX 4090 |
+| 70B | 140 GB | 40-48 GB | A100 (80 GB) or 2x A100 (40 GB) |
+
+### Quantisation trade-offs
+
+- **Q4_K_M** — good balance of quality and memory (most common for on-prem)
+- **Q5_K_M** — slightly better quality, 25% more memory
+- **Q8_0** — near-FP16 quality, double the Q4 memory
+- **FP16** — full precision, requires most memory, best quality
+
+## Docker Compose pattern
+
+```yaml
+services:
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
+      interval: 30s
+      retries: 3
+
+  chromadb:
+    image: chromadb/chroma:latest
+    ports:
+      - "8000:8000"
+    volumes:
+      - chroma_data:/chroma/chroma
+
+  agent:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      LLM_BACKEND: ollama
+      LLM_BASE_URL: http://ollama:11434
+      LLM_MODEL: llama3.2
+      CHROMA_URL: http://chromadb:8000
+    depends_on:
+      ollama:
+        condition: service_healthy
+```
+
+## Air-gapped deployment
+
+For environments with no internet access:
+
+1. **Pre-download models** on a connected machine (`ollama pull`, download GGUF files)
+2. **Transfer via secure media** (USB, approved file transfer)
+3. **Load from local volume** — mount the model directory into the container
+4. **Pre-build Docker images** — save with `docker save`, load with `docker load`
+5. **Embedding models** — download sentence-transformers models and serve locally
+
+## Data sovereignty checklist
+
+- [ ] No API calls leave the local network (verify with network monitoring)
+- [ ] All models are served locally (no cloud model fallback)
+- [ ] Embedding generation is local (not using cloud embedding APIs)
+- [ ] Vector store runs on local infrastructure
+- [ ] Audit logs are stored locally
+- [ ] Model updates follow an approved change process (no auto-download)
+
+## Integration with other skills
+
+- [agent-llm-providers](../agent-llm-providers/SKILL.md) — on-prem provider configuration
+- [agent-context](../agent-context/SKILL.md) — local vector stores and embedding models
+- [agent-guardrails](../agent-guardrails/SKILL.md) — on-prem PII filtering
+- [deployment-build](../../deployment/deployment-build/SKILL.md) — container image builds
+- [deployment-release](../../deployment/deployment-release/SKILL.md) — on-prem release process

--- a/skills/ai-agent-development/agent-types/SKILL.md
+++ b/skills/ai-agent-development/agent-types/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: agent-types
+description: >-
+  Classifies AI agent patterns: chat completion, tool-using, ReAct, A2A protocol,
+  subagents, and multi-agent orchestration. Use when choosing the right agent
+  architecture for a task or comparing agent interaction patterns.
+---
+
+# Agent Types
+
+Taxonomy of AI agent patterns, from simple to complex. Each pattern adds capabilities but also adds complexity — pick the simplest pattern that meets your requirements.
+
+## When to use
+
+- Starting a new agent project and choosing the architecture
+- Deciding whether to add tool use, sub-agents, or multi-agent orchestration
+- Implementing Agent2Agent (A2A) protocol for inter-agent communication
+- Reviewing an agent system for over-engineering or missing capabilities
+
+## Agent taxonomy
+
+### 1. Chat completion agent
+
+Stateless request-response wrapper around an LLM. No tools, no memory, no orchestration.
+
+**Use when:** Simple Q&A, text generation, summarisation, translation.
+
+```
+User prompt → LLM → Response
+```
+
+- Single turn or multi-turn with conversation history in the prompt
+- System prompt defines persona and constraints
+- No external data access beyond the model's training data
+
+### 2. Tool-using agent (ReAct pattern)
+
+Agent with access to external tools (functions, APIs, databases). Follows the Reason-Act-Observe loop: the LLM decides which tool to call, observes the result, and continues reasoning.
+
+**Use when:** The agent needs to query databases, call APIs, perform calculations, or interact with external systems.
+
+```
+User prompt → LLM → Tool call → Tool result → LLM → Response
+                 └──────────────────────────────┘
+                        (loop until done)
+```
+
+- Tool definitions as JSON schema (OpenAI function calling, Anthropic tool use)
+- The LLM selects tools based on the user's intent — not hard-coded routing
+- Guard against infinite loops with a maximum iteration count
+
+### 3. Retrieval-augmented agent (RAG agent)
+
+Tool-using agent where the primary tool is a retrieval system (vector store, search engine, knowledge graph). Combines retrieval with generation.
+
+**Use when:** The agent must answer questions from a document corpus, knowledge base, or structured data that exceeds the context window.
+
+See [agent-context](../agent-context/SKILL.md) for RAG pipeline design.
+
+### 4. Subagent / delegation pattern
+
+A parent agent delegates subtasks to specialised child agents. Each child has its own system prompt, tools, and constraints. The parent orchestrates results.
+
+**Use when:** Tasks are decomposable into independent subtasks with different expertise requirements (e.g. research + code + review).
+
+```
+User prompt → Orchestrator agent
+                 ├─► Research agent → findings
+                 ├─► Code agent → implementation
+                 └─► Review agent → feedback
+              Orchestrator → combined response
+```
+
+- Parent decides task decomposition and aggregation strategy
+- Children can run in parallel when tasks are independent
+- Each child has a focused system prompt and limited tool set
+
+### 5. Multi-agent conversation
+
+Multiple agents collaborate through a shared conversation or message bus. Agents take turns or respond to events. No single orchestrator.
+
+**Use when:** Debate, peer review, simulation, or collaborative problem-solving where multiple perspectives add value.
+
+- Round-robin, random, or LLM-routed turn selection
+- Shared conversation history or message passing
+- Termination conditions (consensus, max turns, human approval)
+
+### 6. Agent2Agent (A2A) protocol agents
+
+Agents communicate across process or network boundaries using a standardised protocol (Google A2A, custom gRPC/REST). Each agent is a service with a defined interface.
+
+**Use when:** Agents are developed by different teams, run in different environments, or need to be composed dynamically.
+
+- Agent card: metadata describing capabilities, input/output schemas
+- Task lifecycle: submit → working → completed/failed
+- Streaming support for long-running tasks
+- Authentication and authorisation between agents
+
+## Decision matrix
+
+| Pattern | Complexity | Tool use | Memory | Multi-model | Use case |
+|---------|-----------|----------|--------|-------------|----------|
+| Chat completion | Low | No | Prompt only | No | Q&A, generation |
+| Tool-using (ReAct) | Medium | Yes | Prompt + tool results | No | Data access, actions |
+| RAG agent | Medium | Yes (retrieval) | Prompt + retrieved docs | No | Knowledge-base Q&A |
+| Subagent | High | Per child | Per child | Yes | Complex decomposable tasks |
+| Multi-agent | High | Per agent | Shared or per agent | Yes | Debate, collaboration |
+| A2A protocol | High | Per service | Per service | Yes | Cross-team, cross-env |
+
+## Anti-patterns
+
+- **Over-orchestration** — using multi-agent when a single tool-using agent suffices
+- **God agent** — one agent with 50+ tools instead of delegating to sub-agents
+- **Missing termination** — no max iterations, leading to infinite tool-calling loops
+- **Tight coupling** — agents that depend on internal implementation details of other agents

--- a/skills/ai-agent-development/agent-visual-dev/SKILL.md
+++ b/skills/ai-agent-development/agent-visual-dev/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: agent-visual-dev
+description: >-
+  Guides visual and GUI-based AI agent development with n8n, Flowise, and
+  LangFlow. Covers low-code orchestration, when to use visual tools vs code,
+  and on-premises self-hosting. Use when evaluating or building agents with
+  visual workflow tools.
+---
+
+# Agent Visual Development
+
+Patterns for building AI agents with visual/GUI tools instead of (or alongside) code. Covers n8n, Flowise, LangFlow, and when visual development is the right choice.
+
+## When to use
+
+- Evaluating visual agent builders for rapid prototyping
+- Non-developers need to create or modify agent workflows
+- Building agent pipelines where visual flow representation aids understanding
+- Comparing visual tools vs code-first frameworks
+- Self-hosting visual tools on-premises
+
+## Tool comparison
+
+| Tool | Focus | Self-hosted | LLM integrations | Agent capabilities |
+|------|-------|-------------|-------------------|--------------------|
+| **n8n** | General workflow automation + AI | Yes (Docker, npm) | OpenAI, Ollama, Anthropic, Azure | AI agent node, tool use, memory, sub-workflows |
+| **Flowise** | LangChain visual builder | Yes (Docker, npm) | All LangChain providers | Chains, agents, RAG, tools, chatflows |
+| **LangFlow** | LangChain/LangGraph visual builder | Yes (pip, Docker) | All LangChain providers | Flows, agents, RAG, custom components |
+| **Dify** | LLM app platform | Yes (Docker) | OpenAI, Ollama, Azure, HuggingFace | Agents, RAG, workflow orchestration |
+| **Rivet** | Visual AI pipeline editor | Desktop app | OpenAI, Anthropic | Graph-based prompt chains, evaluation |
+
+## When visual vs code
+
+| Factor | Visual tools | Code-first |
+|--------|-------------|------------|
+| Prototyping speed | Fast — drag and drop | Slower for initial setup |
+| Complex logic | Limited — hard to express conditional branching | Full control |
+| Version control | Limited — JSON export, harder to diff | Native git workflow |
+| Testing | Manual via UI | Automated test suites |
+| Debugging | Visual trace, step-by-step | Standard debugging tools |
+| Team scaling | Good for small teams, non-devs | Better for engineering teams |
+| Production deployment | Possible but less mature | Standard CI/CD pipelines |
+| On-premises | All tools above support self-hosting | Full control |
+
+### Recommended approach
+
+- **Prototype** with visual tools to validate the agent design
+- **Implement** in code for production systems that need testing, CI/CD, and version control
+- **Hybrid** — use n8n for workflow orchestration, call code-based agents as HTTP services
+
+## n8n for AI agents
+
+n8n stands out as the most general-purpose option with strong AI capabilities:
+
+- **AI Agent node** — built-in ReAct agent with tool use
+- **Memory nodes** — conversation history (buffer, window, vector store-backed)
+- **Tool nodes** — HTTP request, code execution, database queries, calculator
+- **RAG workflow** — document loaders, text splitters, embeddings, vector stores
+- **Sub-workflows** — compose complex agent pipelines from reusable pieces
+- **Self-hosted** — Docker or npm install; runs entirely on-premises
+- **Credentials** — manage API keys securely with built-in credential store
+
+### n8n Docker setup (on-premises)
+
+```yaml
+services:
+  n8n:
+    image: n8nio/n8n:latest
+    ports:
+      - "5678:5678"
+    environment:
+      N8N_BASIC_AUTH_ACTIVE: "true"
+      N8N_BASIC_AUTH_USER: admin
+      N8N_BASIC_AUTH_PASSWORD: changeme
+    volumes:
+      - n8n_data:/home/node/.n8n
+```
+
+## Flowise and LangFlow
+
+Both are visual frontends for LangChain:
+
+- **Flowise** — Node.js based, simpler UI, focuses on chatflows and RAG
+- **LangFlow** — Python based, closer to LangChain/LangGraph API, supports custom Python components
+
+Choose Flowise for quick RAG chatbots. Choose LangFlow when you need LangGraph integration or custom Python components.
+
+## Self-hosting checklist
+
+- [ ] Deploy with Docker Compose (all tools above support it)
+- [ ] Configure persistent storage for workflows and credentials
+- [ ] Set up authentication (basic auth, OAuth, or reverse proxy)
+- [ ] Connect to local LLM server (Ollama) — no cloud API needed
+- [ ] Back up workflow definitions (export JSON, or mount config volume)
+- [ ] Monitor resource usage (CPU, memory, GPU if applicable)
+
+## Integration with other skills
+
+- [agent-frameworks](../agent-frameworks/SKILL.md) — visual tools complement code-first frameworks
+- [agent-on-premises](../agent-on-premises/SKILL.md) — self-hosting visual tools locally
+- [agent-llm-providers](../agent-llm-providers/SKILL.md) — configuring LLM providers in visual tools
+- [deployment-build](../../deployment/deployment-build/SKILL.md) — Docker-based deployment of visual tools

--- a/skills/ai-agent-development/examples.md
+++ b/skills/ai-agent-development/examples.md
@@ -1,0 +1,454 @@
+# AI Agent Development — Examples
+
+Python and C# code examples for common agent patterns. Companion to [SKILL.md](SKILL.md).
+
+## Python examples
+
+### 1. Minimal chat completion agent
+
+No framework required — just the `openai` SDK (works with OpenAI and Ollama):
+
+```python
+from openai import OpenAI
+
+def create_agent(
+    base_url: str = "http://localhost:11434/v1",
+    model: str = "llama3.2",
+    system_prompt: str = "You are a helpful assistant.",
+) -> callable:
+    """Create a simple chat completion agent.
+
+    Args:
+        base_url: LLM API endpoint. Use Ollama for on-premises.
+        model: Model identifier.
+        system_prompt: System instructions for the agent.
+
+    Returns:
+        callable: A function that takes a user message and returns a response.
+    """
+    client = OpenAI(base_url=base_url, api_key="not-needed")
+
+    def chat(user_message: str) -> str:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_message},
+            ],
+        )
+        return response.choices[0].message.content
+
+    return chat
+
+
+agent = create_agent()
+print(agent("What is retrieval-augmented generation?"))
+```
+
+### 2. Tool-using agent with provider abstraction
+
+Framework-free implementation with swappable providers:
+
+```python
+import json
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from openai import OpenAI
+
+
+@dataclass
+class ToolResult:
+    name: str
+    result: str
+
+
+@dataclass
+class AgentResponse:
+    content: str
+    tools_called: list[ToolResult] = field(default_factory=list)
+    model: str = ""
+    total_tokens: int = 0
+
+
+class BaseLLMProvider(ABC):
+    """Abstract LLM provider — swap implementations without changing agent code."""
+
+    @abstractmethod
+    def complete_with_tools(
+        self,
+        messages: list[dict],
+        tools: list[dict],
+        max_iterations: int = 5,
+    ) -> AgentResponse:
+        ...
+
+
+class OpenAICompatibleProvider(BaseLLMProvider):
+    """Provider for OpenAI-compatible APIs (OpenAI, Ollama, vLLM)."""
+
+    def __init__(self, base_url: str, model: str, api_key: str = "not-needed"):
+        self.client = OpenAI(base_url=base_url, api_key=api_key)
+        self.model = model
+
+    def complete_with_tools(
+        self,
+        messages: list[dict],
+        tools: list[dict],
+        max_iterations: int = 5,
+    ) -> AgentResponse:
+        tools_called = []
+        total_tokens = 0
+
+        for _ in range(max_iterations):
+            response = self.client.chat.completions.create(
+                model=self.model,
+                messages=messages,
+                tools=tools if tools else None,
+            )
+            msg = response.choices[0].message
+            total_tokens += response.usage.total_tokens if response.usage else 0
+
+            if not msg.tool_calls:
+                return AgentResponse(
+                    content=msg.content or "",
+                    tools_called=tools_called,
+                    model=self.model,
+                    total_tokens=total_tokens,
+                )
+
+            messages.append(msg.model_dump())
+
+            for tool_call in msg.tool_calls:
+                result = self._execute_tool(
+                    tool_call.function.name,
+                    json.loads(tool_call.function.arguments),
+                )
+                tools_called.append(ToolResult(tool_call.function.name, result))
+                messages.append({
+                    "role": "tool",
+                    "tool_call_id": tool_call.id,
+                    "content": result,
+                })
+
+        return AgentResponse(
+            content="Max iterations reached.",
+            tools_called=tools_called,
+            model=self.model,
+            total_tokens=total_tokens,
+        )
+
+    def _execute_tool(self, name: str, arguments: dict) -> str:
+        """Override or register tool handlers."""
+        return json.dumps({"error": f"Unknown tool: {name}"})
+
+
+def create_provider(backend: str, **kwargs) -> BaseLLMProvider:
+    """Factory for creating LLM providers by backend name.
+
+    Args:
+        backend: Provider identifier ("ollama", "openai", "azure").
+        **kwargs: Provider-specific configuration.
+
+    Returns:
+        BaseLLMProvider: Configured provider instance.
+
+    Raises:
+        ValueError: If the backend is not recognised.
+    """
+    providers = {
+        "ollama": lambda: OpenAICompatibleProvider(
+            base_url=kwargs.get("base_url", "http://localhost:11434/v1"),
+            model=kwargs.get("model", "llama3.2"),
+        ),
+        "openai": lambda: OpenAICompatibleProvider(
+            base_url="https://api.openai.com/v1",
+            model=kwargs.get("model", "gpt-4o"),
+            api_key=kwargs["api_key"],
+        ),
+    }
+    if backend not in providers:
+        raise ValueError(f"Unknown backend: {backend}. Available: {list(providers)}")
+    return providers[backend]()
+```
+
+### 3. RAG agent with LangChain
+
+```python
+from langchain_community.document_loaders import PyPDFLoader
+from langchain_community.vectorstores import Chroma
+from langchain_openai import ChatOpenAI, OpenAIEmbeddings
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import RunnablePassthrough
+from langchain_core.output_parsers import StrOutputParser
+
+
+def build_rag_chain(
+    pdf_path: str,
+    collection_name: str = "docs",
+    llm_model: str = "gpt-4o",
+):
+    """Build a RAG chain from a PDF document.
+
+    Args:
+        pdf_path: Path to the PDF file to index.
+        collection_name: Chroma collection name.
+        llm_model: LLM model identifier.
+
+    Returns:
+        A runnable chain that answers questions from the PDF.
+    """
+    loader = PyPDFLoader(pdf_path)
+    docs = loader.load()
+
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=512,
+        chunk_overlap=64,
+    )
+    chunks = splitter.split_documents(docs)
+
+    vectorstore = Chroma.from_documents(
+        documents=chunks,
+        embedding=OpenAIEmbeddings(),
+        collection_name=collection_name,
+    )
+    retriever = vectorstore.as_retriever(search_kwargs={"k": 4})
+
+    prompt = ChatPromptTemplate.from_messages([
+        ("system", (
+            "Answer the question based on the provided context. "
+            "If the context does not contain the answer, say so.\n\n"
+            "Context:\n{context}"
+        )),
+        ("user", "{question}"),
+    ])
+
+    chain = (
+        {"context": retriever, "question": RunnablePassthrough()}
+        | prompt
+        | ChatOpenAI(model=llm_model)
+        | StrOutputParser()
+    )
+    return chain
+```
+
+### 4. Multi-agent with LangGraph
+
+```python
+from typing import Annotated, TypedDict
+from langgraph.graph import StateGraph, START, END
+from langchain_openai import ChatOpenAI
+
+
+class AgentState(TypedDict):
+    task: str
+    research: str
+    draft: str
+    review: str
+    final: str
+
+
+def researcher(state: AgentState) -> dict:
+    """Research agent gathers information about the task."""
+    llm = ChatOpenAI(model="gpt-4o")
+    result = llm.invoke(
+        f"Research the following topic thoroughly:\n{state['task']}"
+    )
+    return {"research": result.content}
+
+
+def writer(state: AgentState) -> dict:
+    """Writer agent creates a draft from research findings."""
+    llm = ChatOpenAI(model="gpt-4o")
+    result = llm.invoke(
+        f"Write a clear document based on this research:\n{state['research']}"
+    )
+    return {"draft": result.content}
+
+
+def reviewer(state: AgentState) -> dict:
+    """Reviewer agent provides feedback on the draft."""
+    llm = ChatOpenAI(model="gpt-4o")
+    result = llm.invoke(
+        f"Review this draft for accuracy and clarity:\n{state['draft']}"
+    )
+    return {"review": result.content}
+
+
+def build_multi_agent_graph() -> StateGraph:
+    """Build a research-write-review multi-agent pipeline.
+
+    Returns:
+        Compiled LangGraph application.
+    """
+    graph = StateGraph(AgentState)
+    graph.add_node("researcher", researcher)
+    graph.add_node("writer", writer)
+    graph.add_node("reviewer", reviewer)
+
+    graph.add_edge(START, "researcher")
+    graph.add_edge("researcher", "writer")
+    graph.add_edge("writer", "reviewer")
+    graph.add_edge("reviewer", END)
+
+    return graph.compile()
+```
+
+---
+
+## C# examples (Semantic Kernel)
+
+### 1. Minimal chat agent
+
+```csharp
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+var kernel = Kernel.CreateBuilder()
+    .AddOpenAIChatCompletion("gpt-4o", Environment.GetEnvironmentVariable("OPENAI_API_KEY")!)
+    .Build();
+
+var chat = kernel.GetRequiredService<IChatCompletionService>();
+var history = new ChatHistory("You are a helpful assistant.");
+
+history.AddUserMessage("What is retrieval-augmented generation?");
+var response = await chat.GetChatMessageContentAsync(history);
+Console.WriteLine(response.Content);
+```
+
+### 2. Tool-using agent with plugins
+
+```csharp
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Agents;
+using System.ComponentModel;
+
+public class WeatherPlugin
+{
+    [KernelFunction, Description("Get the current weather for a city")]
+    public string GetWeather(
+        [Description("City name")] string city)
+    {
+        // Replace with actual weather API call
+        return $"The weather in {city} is 18°C and partly cloudy.";
+    }
+}
+
+public class CalculatorPlugin
+{
+    [KernelFunction, Description("Calculate a mathematical expression")]
+    public double Calculate(
+        [Description("Mathematical expression")] string expression)
+    {
+        var table = new System.Data.DataTable();
+        return Convert.ToDouble(table.Compute(expression, null));
+    }
+}
+
+// Build kernel with plugins
+var kernel = Kernel.CreateBuilder()
+    .AddOpenAIChatCompletion("gpt-4o", apiKey)
+    .Build();
+
+kernel.Plugins.AddFromType<WeatherPlugin>();
+kernel.Plugins.AddFromType<CalculatorPlugin>();
+
+// Create agent with automatic tool calling
+var agent = new ChatCompletionAgent
+{
+    Kernel = kernel,
+    Name = "ToolAgent",
+    Instructions = "You are a helpful assistant. Use the available tools to answer questions.",
+    Arguments = new KernelArguments(
+        new OpenAIPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() }
+    ),
+};
+
+var thread = new ChatHistoryAgentThread();
+var response = await agent.InvokeAsync("What is the weather in Amsterdam and what is 42 * 17?", thread);
+Console.WriteLine(response.Content);
+```
+
+### 3. Swappable providers (Ollama on-premises)
+
+```csharp
+using Microsoft.SemanticKernel;
+
+// Configuration-driven provider selection
+var backend = Environment.GetEnvironmentVariable("LLM_BACKEND") ?? "ollama";
+var model = Environment.GetEnvironmentVariable("LLM_MODEL") ?? "llama3.2";
+
+var builder = Kernel.CreateBuilder();
+
+switch (backend)
+{
+    case "ollama":
+        builder.AddOpenAIChatCompletion(
+            modelId: model,
+            apiKey: null,
+            httpClient: new HttpClient
+            {
+                BaseAddress = new Uri("http://localhost:11434/v1")
+            });
+        break;
+    case "openai":
+        builder.AddOpenAIChatCompletion(
+            modelId: model,
+            apiKey: Environment.GetEnvironmentVariable("OPENAI_API_KEY")!);
+        break;
+    case "azure":
+        builder.AddAzureOpenAIChatCompletion(
+            deploymentName: model,
+            endpoint: Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT")!,
+            apiKey: Environment.GetEnvironmentVariable("AZURE_OPENAI_KEY")!);
+        break;
+    default:
+        throw new ArgumentException($"Unknown backend: {backend}");
+}
+
+var kernel = builder.Build();
+```
+
+### 4. Multi-agent conversation
+
+```csharp
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Agents;
+using Microsoft.SemanticKernel.Agents.Chat;
+
+var kernel = Kernel.CreateBuilder()
+    .AddOpenAIChatCompletion("gpt-4o", apiKey)
+    .Build();
+
+var researcher = new ChatCompletionAgent
+{
+    Kernel = kernel,
+    Name = "Researcher",
+    Instructions = "You research topics and provide factual information with sources.",
+};
+
+var critic = new ChatCompletionAgent
+{
+    Kernel = kernel,
+    Name = "Critic",
+    Instructions = "You review research for accuracy, bias, and missing perspectives.",
+};
+
+var groupChat = new AgentGroupChat(researcher, critic)
+{
+    ExecutionSettings = new AgentGroupChatSettings
+    {
+        TerminationStrategy = new MaxTurnTermination(maxTurns: 4),
+    },
+};
+
+groupChat.AddChatMessage(new ChatMessageContent(
+    AuthorRole.User,
+    "Analyse the pros and cons of on-premises AI deployment for healthcare."
+));
+
+await foreach (var message in groupChat.InvokeAsync())
+{
+    Console.WriteLine($"[{message.AuthorName}]: {message.Content}");
+}
+```

--- a/skills/ai-agent-development/reference.md
+++ b/skills/ai-agent-development/reference.md
@@ -1,0 +1,143 @@
+# AI Agent Development — Reference
+
+Deep patterns, anti-patterns, and framework comparison for AI agent implementation. Companion to [SKILL.md](SKILL.md).
+
+## Agent design patterns
+
+### 1. Router pattern
+
+A lightweight classifier routes user input to specialised handlers. Not a full agent — no reasoning loop.
+
+```
+User input → Router (classifier / keyword) → Handler A | Handler B | Handler C
+```
+
+- Use when: fixed set of intents, no need for open-ended reasoning
+- Implement with: intent classifier, regex, or small LLM call
+- Avoids the overhead of a full ReAct loop for predictable tasks
+
+### 2. Plan-and-execute pattern
+
+The agent creates a plan first, then executes each step. Separates planning from execution.
+
+```
+User input → Planner LLM → [Step 1, Step 2, Step 3]
+                                    │
+                              Executor (per step) → results
+                                    │
+                              Re-plan if needed
+```
+
+- Use when: complex multi-step tasks, long-running workflows
+- Advantage: the plan is inspectable and modifiable before execution
+- Framework support: LangGraph (plan-and-execute template), AutoGen
+
+### 3. Reflection pattern
+
+After generating output, a second LLM call critiques and refines it.
+
+```
+User input → Generator LLM → draft output → Critic LLM → feedback
+                  ▲                                          │
+                  └──────────────────────────────────────────┘
+                              (refine loop)
+```
+
+- Use when: output quality matters more than latency (writing, code review)
+- Limit iterations (2-3 max) to prevent infinite refinement
+
+### 4. Human-in-the-loop pattern
+
+The agent pauses at decision points and requests human approval before continuing.
+
+- Use when: high-stakes actions (financial transactions, data deletion, deployment)
+- Implement with: LangGraph interrupt nodes, custom approval webhooks
+- Log the human decision for audit trail
+
+### 5. Supervisor pattern
+
+A supervisor agent monitors other agents, intervenes on errors, and ensures quality.
+
+```
+                    Supervisor
+                   /     |     \
+               Agent A  Agent B  Agent C
+```
+
+- Use when: multi-agent systems need quality control
+- The supervisor can re-assign tasks, retry, or escalate to human
+
+## Anti-patterns catalogue
+
+| Anti-pattern | Description | Fix |
+|-------------|-------------|-----|
+| Prompt stuffing | Cramming everything into the system prompt (tools, examples, rules, history) | Split into tools, RAG, and structured prompts |
+| God agent | One agent with 50+ tools | Decompose into specialised sub-agents |
+| Infinite loop | No max iterations on the ReAct loop | Set `max_iterations` (5-15 typical) |
+| Silent failure | Swallowing tool errors | Surface errors to the agent for recovery |
+| Context amnesia | Not persisting conversation state | Add memory (sliding window, summarisation) |
+| Provider coupling | Hard-coding `openai.ChatCompletion.create()` everywhere | Abstract behind provider interface |
+| Eval-free deployment | Shipping agents without systematic evaluation | Build eval suites (accuracy, latency, cost) |
+| Security bypass | Trusting LLM output for system commands | Validate and sandbox all agent actions |
+
+## Framework comparison matrix (detailed)
+
+| Criterion | LangChain | LangGraph | Semantic Kernel | AutoGen | CrewAI |
+|-----------|-----------|-----------|-----------------|---------|--------|
+| Primary language | Python, JS | Python, JS | C#, Python, Java | Python, C# | Python |
+| Agent loop | Built-in AgentExecutor | Custom graph | ChatCompletionAgent | ConversableAgent | Crew/Task |
+| Tool calling | Tool classes, @tool decorator | Same as LangChain | KernelFunction / Plugin | Function decorator | @tool decorator |
+| Multi-agent | Limited (agent supervisor) | Full support (graph nodes) | AgentGroupChat | GroupChat, Swarm | Crew with roles |
+| RAG support | Extensive (100+ loaders) | Same ecosystem | Plugins + connectors | Plugins | Built-in |
+| State management | RunnablePassthrough | Checkpointer (SQLite, Postgres) | Kernel + DI container | Chat history | Task context |
+| Streaming | Yes (astream) | Yes (astream_events) | Yes (streaming kernel) | Yes (streaming) | Limited |
+| Human-in-the-loop | Manual | Interrupt nodes | Filters | Human proxy | Manual |
+| On-premises | Yes (any provider) | Yes | Yes (local endpoints) | Yes | Yes |
+| Production maturity | High (widely adopted) | Growing | High (Microsoft backing) | Growing | Moderate |
+| Learning curve | Medium | Medium-High | Medium | Medium | Low |
+
+## Evaluation approaches
+
+### Offline evaluation
+
+- **Accuracy on test set** — predefined questions with known answers; measure exact match, F1, ROUGE
+- **Tool call accuracy** — does the agent call the right tool with correct arguments?
+- **Retrieval quality** — precision@k, recall@k, nDCG for RAG pipelines
+- **Hallucination rate** — percentage of claims not supported by retrieved context
+
+### Online evaluation
+
+- **User satisfaction** — thumbs up/down, explicit ratings
+- **Task completion rate** — percentage of tasks completed without human escalation
+- **Latency** — time to first token, total response time
+- **Cost per interaction** — total LLM tokens consumed
+
+### Evaluation tools
+
+| Tool | Scope | Notes |
+|------|-------|-------|
+| RAGAS | RAG evaluation | Faithfulness, relevance, context recall |
+| DeepEval | General agent eval | Hallucination, toxicity, tool use |
+| LangSmith | LangChain tracing + eval | Traces, datasets, automated scoring |
+| Promptfoo | Prompt testing | Assertions, comparisons, grading |
+| Custom pytest | Targeted unit tests | Test tool calls, output format, edge cases |
+
+## Security considerations
+
+- **Tool sandboxing** — never let the agent execute arbitrary code without sandboxing (Docker, gVisor)
+- **Output validation** — validate JSON output with Pydantic before acting on it
+- **Credential isolation** — tools should receive scoped credentials, not the agent's full permissions
+- **Network boundaries** — restrict agent HTTP access to allowlisted endpoints
+- **Prompt injection defence** — separate user input from system instructions at the API level (system vs user messages)
+
+## A2A protocol reference
+
+Google's Agent2Agent protocol defines inter-agent communication:
+
+- **Agent card** — JSON metadata at `/.well-known/agent.json` describing capabilities
+- **Task lifecycle** — `POST /tasks` creates a task; status transitions: `submitted → working → completed | failed`
+- **Streaming** — SSE (Server-Sent Events) for real-time progress updates
+- **Authentication** — OAuth2 or API key between agents
+- **Push notifications** — webhook callbacks for async task completion
+
+Key design principle: agents are services with well-defined inputs and outputs, not chat partners.


### PR DESCRIPTION
## Summary

- Adds `ai-agent-development` skill with 7 sub-skills covering agent types, context/RAG, guardrails, swappable LLM providers, on-premises deployment, framework selection, and visual development
- Includes `reference.md` (design patterns, anti-patterns, framework comparison matrix, A2A protocol) and `examples.md` (Python + C# code for chat completion, tool-using, RAG, and multi-agent agents)
- Updates `SKILL_TREE.md` with new "Domain Skills" section, summary table entry, and implementation status

Closes #84

## Files added

| File | Description |
|------|-------------|
| `skills/ai-agent-development/SKILL.md` | Orchestrator: taxonomy, design decisions, architecture diagram |
| `agent-types/SKILL.md` | Chat completion, tool-using, ReAct, A2A, subagents, multi-agent |
| `agent-context/SKILL.md` | RAG pipeline, knowledge graphs, chunking, embeddings, memory |
| `agent-guardrails/SKILL.md` | Input/output guardrails, PII filtering, cost control, audit logging |
| `agent-llm-providers/SKILL.md` | Provider abstraction, factory pattern, open/closed source comparison |
| `agent-on-premises/SKILL.md` | Local serving, GPU provisioning, Docker Compose, air-gapped deploy |
| `agent-frameworks/SKILL.md` | LangChain/LangGraph, Semantic Kernel, AutoGen, CrewAI comparison |
| `agent-visual-dev/SKILL.md` | n8n, Flowise, LangFlow, visual vs code trade-offs |
| `reference.md` | Design patterns (router, plan-execute, reflection), anti-patterns, eval |
| `examples.md` | Python (OpenAI SDK, LangChain, LangGraph) + C# (Semantic Kernel) |

## Test plan

- [x] All 8 SKILL.md files pass `skills-ref validate` locally
- [x] CI `validate-skills` workflow passes on PR
- [x] Review sub-skill cross-links resolve correctly
