### PR TITLE
#82: Add issue-coding TDD orchestrator skill

### DIFF
--- a/skills/COOPERATION.md
+++ b/skills/COOPERATION.md
@@ -4,22 +4,28 @@ How skills compose: sequential vs parallel flows, triggers, and dependencies.
 
 ## Sequential flows
 
-### Issue → Implementation → Integration
+### Issue → Coding → Integration
 
 ```text
 issue-workflow → plan → architecture (or architecture-consult) → design-consult
-  → implementation-construction → quality-gate → integration-commit → integration-pr → code-review → integration-merge
+  → issue-coding → integration-commit → integration-pr → code-review → integration-merge
 ```
 
 During issue creation or revision, **architecture** (orchestrator or sub-skills) can be triggered before or during purpose-alignment, work-down, or acceptance-criteria so requirements and implementation plans reflect architecture concerns.
 
 Each step produces output for the next. No parallelism within this chain.
 
+**Human-in-the-loop pause:** After `issue-workflow` and `plan`, a maintainer may review the issue before coding. Invoke [issue-coding](issue-workflow/issue-coding/SKILL.md) only after that review, or when the issue has `execution:ai-ok` and an explicit go-ahead (typical after external [triage](https://www.skills.sh/mattpocock/skills/triage) → Agent Brief; see [_meta/human-ai-execution.md](_meta/human-ai-execution.md#external-skills)).
+
 ### TDD flow
 
 ```text
-issue-acceptance-criteria → validation-draft → create-validation (optional, full checklist) → test-write → implementation-construction → run-validation
+issue-acceptance-criteria → issue-coding (orchestrator)
+  → validation-draft → test-write → implementation-construction → test-run → quality-gate
+  → create-validation / run-validation (optional, full checklist)
 ```
+
+Prefer **issue-coding** as the single entry for the inner loop; sub-skills above are delegated steps, not optional reordering.
 
 Validation and tests are drafted before implementation. [create-validation](validation/create-validation/SKILL.md) and [run-validation](validation/run-validation/SKILL.md) add executable markdown checklists for issue-driven workflows.
 
@@ -121,7 +127,8 @@ Store **committed** reports under `docs/skills/benchmark/<skill-name>/report.md`
 | New feature idea (architectural) | architecture orchestrator (Initial/Retrofitting/Evolving) |
 | Issue creation or revision | issue-workflow; may invoke architecture before/during purpose-alignment, work-down, acceptance-criteria |
 | Before adding code | architecture-consult, design-consult |
-| After design | implementation-construction |
+| After plan / external triage ready-for-agent | issue-coding (TDD inner loop) |
+| After design | implementation-construction (via issue-coding when issue-driven) |
 | Before commit | quality-gate |
 | Before commit (OpenClaw) | quality-gate + openclaw-security (security audit) |
 | After quality-gate | integration-commit |

--- a/skills/SKILL_TREE.md
+++ b/skills/SKILL_TREE.md
@@ -179,6 +179,9 @@ Adds tags, milestones, assignees, planning references.
 #### 5.8 issue-gh-bulk-scratch
 Creates an EPIC and many issues with `gh`; keeps gitignored `tmp/` body files named 1-1 with GitHub issue numbers; self-assigns.
 
+#### 5.9 issue-coding
+Orchestrates TDD coding inner loop: validation-draft → test-write → implementation-construction → test-run → quality-gate; hand off to integration.
+
 ---
 
 ## Level 1: Planning
@@ -464,7 +467,7 @@ Guides visual/GUI-based agent development with n8n, Flowise, and LangFlow. Cover
 | 2 | requirements | Requirements (arc42 §1–3) | 2.1–2.6 |
 | 3 | architecture | arc42 §4–12 | 3.1–3.10 |
 | 4 | design | Detailed design | 4.1–4.4 |
-| 5 | issue-workflow | Issue lifecycle | 5.1–5.8 |
+| 5 | issue-workflow | Issue lifecycle | 5.1–5.9 |
 | 6 | plan | Planning | 6.1–6.3 |
 | 7 | implementation | Construction | 7.1–7.3 |
 | 8 | validation | Validation | 8.1–8.4, 8.1b |

--- a/skills/_meta/human-ai-execution.md
+++ b/skills/_meta/human-ai-execution.md
@@ -23,7 +23,17 @@ Add an **Execution** block so ownership stays with the issue, not only on the bo
 - [ ] (human-required) …
 ```
 
+## External skills
+
+Some workflow steps rely on skills **not in this repo** — install separately via [Skills CLI](https://github.com/vercel-labs/skills) or [skills.sh](https://www.skills.sh/). Install and listing conventions: [skills/README.md § External and vendor skills](../README.md#external-and-vendor-skills).
+
+| Skill | Role in this workflow | Reference |
+|-------|----------------------|-----------|
+| **triage** | Classify issues; post Agent Brief; apply `execution:ai-ok` before AFK coding | <https://www.skills.sh/mattpocock/skills/triage> |
+| **grill-with-docs** | Sharpen vague requirements; resolve terms against `CONTEXT.md`; produce detailed acceptance criteria before coding | <https://www.skills.sh/mattpocock/skills/grill-with-docs> |
+
 ## Relation to skills
 
 - [v-model](../v-model/SKILL.md) and [v-model-retrofit](../v-model/v-model-retrofit/SKILL.md) often produce **human-review** artefacts (tests and docs that encode intent).
 - [issue-workflow](../issue-workflow/SKILL.md) should still define clear acceptance criteria; humans remain accountable for what “done” means in regulated contexts.
+- After external **triage** marks an issue ready for agents (`execution:ai-ok`, Agent Brief comment), [issue-coding](../issue-workflow/issue-coding/SKILL.md) runs the TDD inner loop; [integration](../integration/SKILL.md) follows human merge review.

--- a/skills/issue-workflow/SKILL.md
+++ b/skills/issue-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-workflow
-description: Orchestrates issue lifecycle from idea to closed. Use when creating, refining, or validating a GitHub issue; triggers sub-skills (5.1–5.7) as needed. New issues assign the trigger user for explicit ownership and review.
+description: Orchestrates issue lifecycle from idea to closed. Use when creating, refining, or validating a GitHub issue; triggers sub-skills (5.1–5.9) as needed. New issues assign the trigger user for explicit ownership and review.
 ---
 
 # Issue Workflow
@@ -25,6 +25,7 @@ Orchestrates the GitHub issue lifecycle per [GitHub Issue Lifecycle](https://doc
 8. **Metadata** — [issue-metadata](issue-metadata/SKILL.md). Tags, milestones, assignees (always assign the person who triggered the issue—directly or indirectly—so ownership and review are explicit).
 9. **Bulk EPIC + children with `gh` (optional)** — [issue-gh-bulk-scratch](issue-gh-bulk-scratch/SKILL.md). When creating many related issues at once: gitignored `tmp/EPIC-#.md` and `tmp/ISSUE-#.md` named **1-1** with GitHub issue numbers, and `--assignee @me` (or batch `gh issue edit`) so each item shows on the assignee’s list.
 10. **Draft issue** — Combine into issue body with Goal, Tasks, Acceptance Criteria, Out of Scope, Estimate, Metadata.
+11. **Coding (optional)** — After [plan](../plan/SKILL.md) and any human review, chain to [issue-coding](issue-coding/SKILL.md) for the TDD inner loop (tests-first → construction → quality-gate). Typical after external [triage](https://www.skills.sh/mattpocock/skills/triage) marks the issue `ready-for-agent` with `execution:ai-ok`.
 
 ## Instructions
 
@@ -37,6 +38,7 @@ Orchestrates the GitHub issue lifecycle per [GitHub Issue Lifecycle](https://doc
 7. Run metadata; add labels, milestone, and assignees (default: assign the trigger user per issue-metadata).
 8. If bulk-filing an EPIC and many sub-issues with `gh`, use [issue-gh-bulk-scratch](issue-gh-bulk-scratch/SKILL.md) for local 1-1 `tmp` names and self-assign.
 9. Assemble final issue draft for `gh issue create` or paste into GitHub UI.
+10. When implementation is authorized, invoke [issue-coding](issue-coding/SKILL.md) (do not skip validation-draft).
 
 ## Output format
 

--- a/skills/issue-workflow/issue-coding/SKILL.md
+++ b/skills/issue-workflow/issue-coding/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: issue-coding
+description: >-
+  Orchestrates the TDD coding inner loop for a validated issue on a feature branch.
+  Use when acceptance criteria exist, plan/branch are done, and implementation begins;
+  runs validation-draft first, then construction, test-run, and quality-gate as exit.
+---
+
+# Issue coding
+
+Thin orchestrator for the **coding inner loop** between [plan](../../plan/SKILL.md) (branch + tasks ready) and [integration](../../integration/SKILL.md) (commit, PR, merge). Does not redefine issues, create branches, or open PRs.
+
+## When to use
+
+- A GitHub issue has **acceptance criteria** (mandatory) and a **feature branch** exists
+- [issue-workflow](../SKILL.md) (5.1–5.7) and [plan](../../plan/SKILL.md) are complete
+- The agent or human is starting implementation (not planning or merging)
+
+Acceptance criteria are the **target function** for AI-assisted coding: they define what “done” means for this session. Without them, stop and return to [issue-acceptance-criteria](../issue-acceptance-criteria/SKILL.md) or external [grill-with-docs](https://www.skills.sh/mattpocock/skills/grill-with-docs) until criteria are testable and documented on the issue (see [_meta/human-ai-execution.md](../../_meta/human-ai-execution.md#external-skills)).
+
+## Acceptance criteria (required, stable during coding)
+
+**Before coding:** Criteria must be specific enough to drive [validation-draft](../../validation/validation-draft/SKILL.md) and tests — copy-pastable checks, expected outcomes, not vague goals. If the issue body is thin, run **grill-with-docs** (or [issue-workflow](../SKILL.md) acceptance-criteria sub-skill) with the human until criteria are written on the issue.
+
+**During the coding loop:** Treat acceptance criteria as **frozen** unless changed through an explicit human agreement:
+
+- Human approves an update in chat (human-in-the-loop), **or**
+- The change is recorded in a **GitHub issue comment** or **PR comment** that the agent (or reviewer) can cite.
+
+Do not silently reinterpret, expand, or rewrite criteria mid-implementation. Scope creep belongs in a new issue or an agreed issue/PR comment first.
+
+## Preconditions (guard)
+
+Stop and resolve before coding if any check fails:
+
+1. **Issue is implementation-ready** — body includes testable acceptance criteria (checkboxes); each maps to a verifiable outcome. If missing or vague, stop — use [issue-acceptance-criteria](../issue-acceptance-criteria/SKILL.md) or external [grill-with-docs](https://www.skills.sh/mattpocock/skills/grill-with-docs) before continuing. Prefer an **Agent Brief** comment from external [triage](https://www.skills.sh/mattpocock/skills/triage) when present; it is the contract for AFK agents (see [_meta/human-ai-execution.md](../../_meta/human-ai-execution.md#external-skills)).
+2. **Triage / execution** — issue carries `execution:ai-ok` **or** the maintainer explicitly started coding in chat. If the issue has `execution:human-required` or `execution:human-review` without approval, pause for human sign-off (see [_meta/human-ai-execution.md](../../_meta/human-ai-execution.md)).
+3. **Branch** — current branch is not `main`/`master`; matches repo convention (`feature/NNN-…`, etc.). If missing, run [plan-branch-strategy](../../plan-branch-strategy/SKILL.md) via `plan` first.
+4. **Scope** — re-read **Out of Scope** on the issue; do not expand into integration or new issue drafting.
+
+**Human-in-the-loop pause:** After issue-workflow and plan, a maintainer may review the issue before invoking this skill. Do not start coding until that review completes unless `execution:ai-ok` and the user (or agent brief) explicitly authorizes implementation.
+
+## Flow (mandatory order)
+
+Do not skip or reorder steps 1–5.
+
+| Step | Skill | Purpose |
+|------|--------|---------|
+| 1 | [validation-draft](../../validation/validation-draft/SKILL.md) | **TDD:** draft tests/scenarios from acceptance criteria **before** production code |
+| 2 | [test-write](../../test/test-write/SKILL.md) | Implement failing tests where automation applies |
+| 3 | [implementation-construction](../../implementation/implementation-construction/SKILL.md) | Write or change code to satisfy tests and criteria |
+| 4 | [test-run](../../test/test-run/SKILL.md) | Red/green loop until the suite passes |
+| 5 | [quality-gate](../../quality-gate/SKILL.md) | Lint, format, type-check, tests — **exit condition** |
+
+Optional within step 1–2: [create-validation](../../validation/create-validation/SKILL.md) for a full executable checklist when the issue warrants it.
+
+### Inner loop
+
+After step 3, repeat **test-run → fix (construction) → test-run** until green. Then run **quality-gate** once. If quality-gate fails, fix and re-run from the failing check (usually construction + test-run + quality-gate).
+
+## Exit and handoff
+
+**Done for this skill when:** [quality-gate](../../quality-gate/SKILL.md) passes on the feature branch.
+
+**Next:** [integration](../../integration/SKILL.md) — commit, PR, review, merge. Do not open a PR inside `issue-coding`.
+
+## Instructions
+
+1. Run the **preconditions** guard; fetch issue with `gh issue view NNN` if needed.
+2. Run **validation-draft** against every acceptance criterion; produce scenarios or test plan.
+3. Run **test-write** for automated coverage; expect red tests before implementation.
+4. Run **implementation-construction** for the planned tasks only; satisfy the **frozen** acceptance criteria (see above).
+5. Run **test-run**; iterate until pass.
+6. Run **quality-gate**; fix until pass.
+7. Report: branch name, tests run, quality-gate result, and that work is ready for **integration**.
+
+## Out of scope
+
+- Issue definition, duplicates, estimates ([issue-workflow](../SKILL.md) 5.1–5.7)
+- Rewriting acceptance criteria without human agreement or issue/PR comment
+- Branch creation and task breakdown ([plan](../../plan/SKILL.md))
+- Commit, PR, merge ([integration](../../integration/SKILL.md))
+- Staleness detection if `main` diverged since issue creation (user must request explicit re-validation)
+- CI pipeline specifics beyond what quality-gate already covers
+
+## Integration
+
+- Chained from [issue-workflow](../SKILL.md) optional step 11 after planning.
+- Composes with [COOPERATION.md](../../COOPERATION.md) TDD and issue → coding → integration flows.
+- External [triage](https://www.skills.sh/mattpocock/skills/triage) → `ready-for-agent` + Agent Brief + `execution:ai-ok` is the typical entry for AFK agents on this repo.
+- V-model: optional pairing via [v-model-implementation-unit](../../v-model/v-model-implementation-unit/SKILL.md).

--- a/skills/software-engineering-process/SKILL.md
+++ b/skills/software-engineering-process/SKILL.md
@@ -18,7 +18,7 @@ Entry orchestrator for the lifecycle in [SKILL_TREE.md](../SKILL_TREE.md). It do
 1. **Shape the problem** — [ideation](../ideation/SKILL.md) (optional), then [issue-workflow](../issue-workflow/SKILL.md) so work is tracked with acceptance criteria.
 2. **Plan** — [plan](../plan/SKILL.md) (branch strategy, tasks, dependencies).
 3. **Design** — [architecture](../architecture/SKILL.md) and [design](../design/SKILL.md) as needed for the change size.
-4. **Build** — [implementation](../implementation/SKILL.md); [quality-gate](../quality-gate/SKILL.md) before commit.
+4. **Build** — [issue-coding](../issue-workflow/issue-coding/SKILL.md) (TDD inner loop) or [implementation](../implementation/SKILL.md) for scoped edits; [quality-gate](../quality-gate/SKILL.md) before commit.
 5. **Integrate** — [integration](../integration/SKILL.md) (commit → PR → review → merge).
 6. **Ship & run** — [deployment](../deployment/SKILL.md) then [operations](../operations/SKILL.md).
 7. **Sustain** — [maintenance](../maintenance/SKILL.md), [governance](../governance/SKILL.md) as needed.


### PR DESCRIPTION
## Summary

- Adds **5.9 issue-coding** — thin orchestrator for the TDD inner loop between `plan` and `integration` (validation-draft → test-write → implementation-construction → test-run → quality-gate).
- Requires stable, testable acceptance criteria before coding; documents frozen criteria during the loop unless changed via human agreement or issue/PR comments.
- Wires `COOPERATION.md`, `SKILL_TREE.md`, `issue-workflow`, and `software-engineering-process`; documents external **triage** and **grill-with-docs** skills in `_meta/human-ai-execution.md`.

Closes #82

## Test plan

- [x] `npx skills-ref@0.1.5 validate skills/issue-workflow/issue-coding` passes locally
- [ ] CI `validate-skills` workflow passes on PR
- [ ] Review acceptance-criteria / triage / human-in-the-loop wording in `issue-coding/SKILL.md`
