### PR TITLE
#26: Add architecture-deployment and architecture-quality skills

### DIFF
--- a/docs/skills/audit-results.md
+++ b/docs/skills/audit-results.md
@@ -9,13 +9,13 @@
 
 ## Executive summary
 
-Audit of 82+ skill files across workspace locations (historical). Canonical set: `pkuppens/skills/` — **108** `SKILL.md` files as of 2026-05-17 (#26 quick wins: `architecture-deployment`, `architecture-quality`). Regenerate the list with the commands below; overlaps and mapping for *other repos* remain valid at a high level. `babblr` has no skills. `~/.claude/skills` not audited (likely symlinked to pkuppens or user-specific).
+Audit of 82+ skill files across workspace locations (historical). Canonical set: `pkuppens/skills/` — **109** `SKILL.md` files as of 2026-05-23 (#26: `architecture-deployment`, `architecture-quality`; #97: `issue-coding`). Regenerate the list with the commands below; overlaps and mapping for *other repos* remain valid at a high level. `babblr` has no skills. `~/.claude/skills` not audited (likely symlinked to pkuppens or user-specific).
 
 ---
 
 ## 1. Inventory by location
 
-### 1.1 pkuppens/skills/ (canonical) — **108** `SKILL.md` files
+### 1.1 pkuppens/skills/ (canonical) — **109** `SKILL.md` files
 
 The static table below is **not** duplicated here (it went stale quickly). Use one of:
 

--- a/docs/skills/audit-results.md
+++ b/docs/skills/audit-results.md
@@ -9,13 +9,13 @@
 
 ## Executive summary
 
-Audit of 82+ skill files across workspace locations (historical). Canonical set: `pkuppens/skills/` — **94** `SKILL.md` files as of 2026-04-10 (#59–#65). Regenerate the list with the commands below; overlaps and mapping for *other repos* remain valid at a high level. `babblr` has no skills. `~/.claude/skills` not audited (likely symlinked to pkuppens or user-specific).
+Audit of 82+ skill files across workspace locations (historical). Canonical set: `pkuppens/skills/` — **108** `SKILL.md` files as of 2026-05-17 (#26 quick wins: `architecture-deployment`, `architecture-quality`). Regenerate the list with the commands below; overlaps and mapping for *other repos* remain valid at a high level. `babblr` has no skills. `~/.claude/skills` not audited (likely symlinked to pkuppens or user-specific).
 
 ---
 
 ## 1. Inventory by location
 
-### 1.1 pkuppens/skills/ (canonical) — **94** `SKILL.md` files
+### 1.1 pkuppens/skills/ (canonical) — **108** `SKILL.md` files
 
 The static table below is **not** duplicated here (it went stale quickly). Use one of:
 

--- a/skills/COOPERATION.md
+++ b/skills/COOPERATION.md
@@ -72,10 +72,10 @@ The [architecture](architecture/SKILL.md) orchestrator routes by mode:
 | Mode | When | Sub-skills (sequence) |
 |------|------|------------------------|
 | **Initial** | Greenfield project | architecture-solution-strategy → architecture-building-blocks |
-| **Retrofitting** | Undocumented codebase | architecture-document-existing (→ architecture-runtime, architecture-building-blocks for delegation) |
+| **Retrofitting** | Undocumented codebase | architecture-document-existing (→ architecture-runtime, architecture-building-blocks, architecture-deployment, architecture-quality for delegation) |
 | **Evolving** | Change or extend | architecture-decisions → architecture-risks-debt (as needed) |
 
-Also: architecture-runtime (flows), architecture-crosscutting (rules), architecture-glossary (terms).
+Also: architecture-runtime (flows), architecture-deployment (topology, compose/infra), architecture-quality (NFR scenarios), architecture-crosscutting (rules), architecture-glossary (terms).
 
 ### When to trigger architecture
 

--- a/skills/SKILL_TREE.md
+++ b/skills/SKILL_TREE.md
@@ -486,7 +486,7 @@ Guides visual/GUI-based agent development with n8n, Flowise, and LangFlow. Cover
 
 ## Implementation Status
 
-*Inventory: **108** `SKILL.md` files under `pkuppens/skills/` (2026-05-17, #26: `architecture-deployment`, `architecture-quality`; prior #57, #59–#65, #67, #84). See [audit-results.md](../docs/skills/audit-results.md) for how to regenerate the list.*
+*Inventory: **109** `SKILL.md` files under `pkuppens/skills/` (2026-05-23, #26: `architecture-deployment`, `architecture-quality`; #97: `issue-coding`; prior #57, #59–#65, #67, #84). See [audit-results.md](../docs/skills/audit-results.md) for how to regenerate the list.*
 
 | Skill | Status |
 | skill-creation | ✅ implemented |

--- a/skills/SKILL_TREE.md
+++ b/skills/SKILL_TREE.md
@@ -486,12 +486,12 @@ Guides visual/GUI-based agent development with n8n, Flowise, and LangFlow. Cover
 
 ## Implementation Status
 
-*Inventory: **106** `SKILL.md` files under `pkuppens/skills/` (2026-05-12, #57, #59–#65, #67, #84). See [audit-results.md](../docs/skills/audit-results.md) for how to regenerate the list.*
+*Inventory: **108** `SKILL.md` files under `pkuppens/skills/` (2026-05-17, #26: `architecture-deployment`, `architecture-quality`; prior #57, #59–#65, #67, #84). See [audit-results.md](../docs/skills/audit-results.md) for how to regenerate the list.*
 
 | Skill | Status |
 | skill-creation | ✅ implemented |
 | issue-workflow (5.x) | ✅ implemented |
-| architecture (3.x) | ✅ implemented (#28: sir-read-a-lot arch skills merged) |
+| architecture (3.x) | ✅ implemented (#28; #26: `architecture-deployment` 3.5, `architecture-quality` 3.8) |
 | design (4.1) | ✅ implemented |
 | implementation (7.1) | ✅ implemented |
 | validation (8.1) | ✅ implemented |

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -71,7 +71,9 @@ Output follows the sub-skill(s) invoked. Orchestrator output summarizes mode and
 | Sub-skill | When |
 |-----------|------|
 | [architecture-runtime](architecture-runtime/SKILL.md) | Document technical execution paths, sequences |
+| [architecture-deployment](architecture-deployment/SKILL.md) | Document deployment topology (arc42 §7) |
 | [architecture-crosscutting](architecture-crosscutting/SKILL.md) | Define dependency rules, layer boundaries, architecture tests |
+| [architecture-quality](architecture-quality/SKILL.md) | Quality tree and scenarios (arc42 §10) |
 | [architecture-glossary](architecture-glossary/SKILL.md) | Maintain ubiquitous language, resolve terminology |
 
 These can be invoked from architecture-document-existing during retrofitting, or directly when needed.

--- a/skills/architecture/architecture-deployment/SKILL.md
+++ b/skills/architecture/architecture-deployment/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: architecture-deployment
+description: "Documents deployment topology: infrastructure, containers, and mapping of software to infra (arc42 §7). Use when describing how the system is deployed or updating deployment docs."
+---
+
+# Architecture Deployment
+
+Documents how software is mapped to infrastructure. Aligns with arc42 §7 (deployment view).
+
+## When to use
+
+- Greenfield: first deployment topology for a new system
+- New environments (staging, DR) or hosting changes
+- Before release work — align with [deployment-release](../../deployment/deployment-release/SKILL.md)
+
+## Outputs
+
+- `docs/architecture/07-deployment.md` — deployment view narrative
+- `docs/architecture/diagrams/deployment.mmd` — optional topology diagram (Mermaid)
+
+## Instructions
+
+1. **Inventory runtime units** — services, workers, databases, queues, object storage, CDN.
+2. **Map to infrastructure** — hosts, regions, clusters, serverless, managed services.
+3. **Document environments** — dev, staging, production; what differs (scale, secrets, URLs).
+4. **Show communication** — ingress, egress, VPC/subnet boundaries, TLS termination.
+5. **Link building blocks** — each deployable maps to a component from §5.
+6. **Note operational hooks** — health checks, config sources, secrets management (no secret values in docs).
+
+## Deployment doc format
+
+```markdown
+# Deployment (arc42 §7)
+
+## Environments
+| Environment | Purpose | Hosting |
+|-------------|---------|---------|
+
+## Topology
+[Diagram or bullet list: nodes and connections]
+
+## Mapping: software → infrastructure
+| Component | Artifact | Runtime | Notes |
+
+## Cross-cutting deployment concerns
+- Scaling, backups, DR, observability endpoints
+```
+
+## Integration
+
+- Complements [architecture-building-blocks](../architecture-building-blocks/SKILL.md) (what) with where/how it runs.
+- [deployment-build](../../deployment/deployment-build/SKILL.md) and [deployment-release](../../deployment/deployment-release/SKILL.md) execute releases; this skill documents the target topology.
+- Parent: [architecture](../SKILL.md).

--- a/skills/architecture/architecture-quality/SKILL.md
+++ b/skills/architecture/architecture-quality/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: architecture-quality
+description: "Documents quality tree and quality scenarios; maps to requirements (arc42 §10). Use when defining non-functional goals, scenarios, or acceptance of quality attributes."
+---
+
+# Architecture Quality
+
+Documents quality goals as scenarios the architecture must satisfy. Aligns with arc42 §10 (quality requirements).
+
+## When to use
+
+- Defining or refining non-functional requirements (performance, security, availability)
+- Before major design decisions — test options against quality scenarios
+- Pairing with [requirements-goals](../../requirements/requirements-goals/SKILL.md) for top-level goals
+
+## Outputs
+
+- `docs/architecture/10-quality.md` — quality tree and scenarios
+- Trace links to requirements and ADRs where decisions affect quality
+
+## Instructions
+
+1. **List quality attributes** — e.g. performance, security, maintainability, usability, compliance.
+2. **Build a quality tree** — refine each attribute into measurable sub-topics.
+3. **Write scenarios** — stimulus / environment / artefact / response / measure (ISO 25010 style).
+4. **Map to requirements** — link scenario IDs to requirement or issue IDs.
+5. **Record architecture tactics** — caching, redundancy, authZ — without duplicating full ADR text (link to §9).
+
+## Quality scenario format
+
+```markdown
+# Quality (arc42 §10)
+
+## Quality tree
+- Performance
+  - API latency under load
+  - Batch throughput
+
+## Scenarios
+| ID | Attribute | Stimulus | Response | Measure |
+|----|-----------|----------|----------|---------|
+| QS-01 | Performance | 100 RPS sustained | p95 < 200ms | load test |
+```
+
+## Integration
+
+- Informs [design](../../design/SKILL.md) and [quality-gate](../../quality-gate/SKILL.md) checks.
+- [architecture-risks-debt](../architecture-risks-debt/SKILL.md) when scenarios reveal unacceptable risk.
+- Parent: [architecture](../SKILL.md).


### PR DESCRIPTION
## Summary

- Adds **architecture-deployment** (arc42 §7) and **architecture-quality** (arc42 §10) `SKILL.md` bodies for SKILL_TREE slots 3.5 and 3.8.
- Wires both into the architecture orchestrator and `COOPERATION.md`.
- Updates skill inventory to **109** (includes #97 `issue-coding` on `main`).

Completes remaining arc42 quick wins from epic #26 (epic already closed).

## Test plan

- [x] `npx skills-ref@0.1.5 validate` on new skill directories
- [x] CI `validate-skills` on PR https://github.com/pkuppens/pkuppens/actions/runs/26328633873 (likely deleted by now)

## Review notes

Code review (pre-PR): no Critical issues; inventory + COOPERATION fixes applied in second commit.
