### PR TITLE
#95: Self-owned SKILL.md frontmatter validation (script + CI + pre-commit)

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -1,16 +1,18 @@
-# Validate SKILL.md frontmatter against agentskills.io (skills-ref).
-# See docs/skills/decisions/001-skill-validation-and-tooling.md
+# Validate SKILL.md frontmatter against agentskills.io specification.
+# Self-owned script + skills-ref reference checker (see ADR 001).
 name: Validate skills
 
 on:
   pull_request:
     paths:
       - "skills/**"
+      - "scripts/validate-skill-frontmatter.sh"
       - ".github/workflows/validate-skills.yml"
   push:
     branches: [main]
     paths:
       - "skills/**"
+      - "scripts/validate-skill-frontmatter.sh"
       - ".github/workflows/validate-skills.yml"
   workflow_dispatch: {}
 
@@ -27,6 +29,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Validate frontmatter (self-owned)
+        shell: bash
+        run: bash scripts/validate-skill-frontmatter.sh skills/
 
       - name: Set up Node.js
         uses: actions/setup-node@v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,11 @@ repos:
     rev: v0.22.1
     hooks:
       - id: markdownlint-cli2
+  - repo: local
+    hooks:
+      - id: validate-skill-frontmatter
+        name: Validate SKILL.md frontmatter
+        entry: bash scripts/validate-skill-frontmatter.sh skills/
+        language: system
+        files: ^skills/.*SKILL\.md$
+        pass_filenames: false

--- a/docs/skills/audit-results.md
+++ b/docs/skills/audit-results.md
@@ -9,13 +9,13 @@
 
 ## Executive summary
 
-Audit of 82+ skill files across workspace locations (historical). Canonical set: `pkuppens/skills/` — **108** `SKILL.md` files as of 2026-05-17 (#26 quick wins: `architecture-deployment`, `architecture-quality`). Regenerate the list with the commands below; overlaps and mapping for *other repos* remain valid at a high level. `babblr` has no skills. `~/.claude/skills` not audited (likely symlinked to pkuppens or user-specific).
+Audit of 82+ skill files across workspace locations (historical). Canonical set: `pkuppens/skills/` — **109** `SKILL.md` files as of 2026-05-23 (#26: `architecture-deployment`, `architecture-quality`; #97: `issue-coding`). Regenerate the list with the commands below; overlaps and mapping for *other repos* remain valid at a high level. `babblr` has no skills. `~/.claude/skills` not audited (likely symlinked to pkuppens or user-specific).
 
 ---
 
 ## 1. Inventory by location
 
-### 1.1 pkuppens/skills/ (canonical) — **108** `SKILL.md` files
+### 1.1 pkuppens/skills/ (canonical) — **109** `SKILL.md` files
 
 The static table below is **not** duplicated here (it went stale quickly). Use one of:
 

--- a/docs/skills/audit-results.md
+++ b/docs/skills/audit-results.md
@@ -9,13 +9,13 @@
 
 ## Executive summary
 
-Audit of 82+ skill files across workspace locations (historical). Canonical set: `pkuppens/skills/` — **94** `SKILL.md` files as of 2026-04-10 (#59–#65). Regenerate the list with the commands below; overlaps and mapping for *other repos* remain valid at a high level. `babblr` has no skills. `~/.claude/skills` not audited (likely symlinked to pkuppens or user-specific).
+Audit of 82+ skill files across workspace locations (historical). Canonical set: `pkuppens/skills/` — **108** `SKILL.md` files as of 2026-05-17 (#26 quick wins: `architecture-deployment`, `architecture-quality`). Regenerate the list with the commands below; overlaps and mapping for *other repos* remain valid at a high level. `babblr` has no skills. `~/.claude/skills` not audited (likely symlinked to pkuppens or user-specific).
 
 ---
 
 ## 1. Inventory by location
 
-### 1.1 pkuppens/skills/ (canonical) — **94** `SKILL.md` files
+### 1.1 pkuppens/skills/ (canonical) — **108** `SKILL.md` files
 
 The static table below is **not** duplicated here (it went stale quickly). Use one of:
 

--- a/scripts/validate-skill-frontmatter.sh
+++ b/scripts/validate-skill-frontmatter.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Validate SKILL.md frontmatter against the agentskills.io specification.
+# https://agentskills.io/specification
+#
+# Usage: bash scripts/validate-skill-frontmatter.sh [skills-directory]
+#   Default directory: skills/
+#
+# Exit codes:
+#   0 — all skills passed
+#   1 — one or more skills failed validation
+
+set -euo pipefail
+
+SKILLS_DIR="${1:-skills}"
+passed=0
+failed=0
+failed_files=()
+
+# Extract the raw value after "key:" from frontmatter text.
+# Handles both bare values and quoted values (single or double quotes).
+extract_field() {
+  local frontmatter="$1"
+  local key="$2"
+  local line
+  line=$(echo "$frontmatter" | grep -m1 "^${key}:" || true)
+  if [[ -z "$line" ]]; then
+    echo ""
+    return
+  fi
+  local value="${line#*: }"
+  # Strip surrounding quotes if present
+  value="${value#\"}"
+  value="${value%\"}"
+  value="${value#\'}"
+  value="${value%\'}"
+  # Trim leading/trailing whitespace
+  value="$(echo "$value" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  echo "$value"
+}
+
+validate_skill() {
+  local file="$1"
+  local errors=()
+
+  # --- Frontmatter extraction ---
+  # Read the file content and check for --- delimiters
+  local content
+  content=$(cat "$file")
+
+  local first_line
+  first_line=$(head -n1 "$file" | tr -d '\r')
+  if [[ "$first_line" != "---" ]]; then
+    errors+=("missing YAML frontmatter (file does not start with ---)")
+    printf "  FAIL  %s\n" "$file"
+    for err in "${errors[@]}"; do
+      printf "        - %s\n" "$err"
+    done
+    return 1
+  fi
+
+  # Extract frontmatter between first and second --- (strip \r for CRLF files)
+  local frontmatter
+  frontmatter=$(awk 'NR==1 && /^---\r?$/{found=1; next} found && /^---\r?$/{exit} found{print}' "$file" | tr -d '\r')
+
+  if [[ -z "$frontmatter" ]]; then
+    errors+=("empty YAML frontmatter")
+    printf "  FAIL  %s\n" "$file"
+    for err in "${errors[@]}"; do
+      printf "        - %s\n" "$err"
+    done
+    return 1
+  fi
+
+  # --- name validation ---
+  local name
+  name=$(extract_field "$frontmatter" "name")
+
+  if [[ -z "$name" ]]; then
+    errors+=("missing required field: name")
+  else
+    local name_len=${#name}
+    if (( name_len > 64 )); then
+      errors+=("name exceeds 64 characters (got ${name_len})")
+    fi
+
+    if ! echo "$name" | grep -qE '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'; then
+      errors+=("name '${name}' does not match pattern: lowercase alphanumeric + hyphens, no leading/trailing/consecutive hyphens")
+    fi
+
+    if echo "$name" | grep -q '\-\-'; then
+      errors+=("name '${name}' contains consecutive hyphens")
+    fi
+
+    # name must match parent directory
+    local parent_dir
+    parent_dir=$(basename "$(dirname "$file")")
+    if [[ "$name" != "$parent_dir" ]]; then
+      errors+=("name '${name}' does not match parent directory '${parent_dir}'")
+    fi
+  fi
+
+  # --- description validation ---
+  local description
+  description=$(extract_field "$frontmatter" "description")
+
+  if [[ -z "$description" ]]; then
+    errors+=("missing required field: description")
+  else
+    local desc_len=${#description}
+    if (( desc_len > 1024 )); then
+      errors+=("description exceeds 1024 characters (got ${desc_len})")
+    fi
+  fi
+
+  # --- compatibility validation (optional, max 500 chars) ---
+  local compatibility
+  compatibility=$(extract_field "$frontmatter" "compatibility")
+  if [[ -n "$compatibility" ]]; then
+    local compat_len=${#compatibility}
+    if (( compat_len > 500 )); then
+      errors+=("compatibility exceeds 500 characters (got ${compat_len})")
+    fi
+  fi
+
+  # --- Report ---
+  if [[ ${#errors[@]} -eq 0 ]]; then
+    printf "  OK    %s\n" "$file"
+    return 0
+  else
+    printf "  FAIL  %s\n" "$file"
+    for err in "${errors[@]}"; do
+      printf "        - %s\n" "$err"
+    done
+    return 1
+  fi
+}
+
+# --- Main ---
+if [[ ! -d "$SKILLS_DIR" ]]; then
+  echo "Error: directory '${SKILLS_DIR}' does not exist." >&2
+  exit 1
+fi
+
+echo "Validating SKILL.md frontmatter in ${SKILLS_DIR}/ ..."
+echo ""
+
+while IFS= read -r -d '' skill_md; do
+  if validate_skill "$skill_md"; then
+    passed=$(( passed + 1 ))
+  else
+    failed=$(( failed + 1 ))
+    failed_files+=("$skill_md")
+  fi
+done < <(find "$SKILLS_DIR" -name 'SKILL.md' -print0 | sort -z)
+
+echo ""
+echo "--- Summary ---"
+echo "Passed: ${passed}"
+echo "Failed: ${failed}"
+echo "Total:  $(( passed + failed ))"
+
+if [[ "$failed" -gt 0 ]]; then
+  echo ""
+  echo "Failed files:"
+  for f in "${failed_files[@]}"; do
+    echo "  - ${f}"
+  done
+  exit 1
+fi

--- a/skills/COOPERATION.md
+++ b/skills/COOPERATION.md
@@ -72,10 +72,10 @@ The [architecture](architecture/SKILL.md) orchestrator routes by mode:
 | Mode | When | Sub-skills (sequence) |
 |------|------|------------------------|
 | **Initial** | Greenfield project | architecture-solution-strategy → architecture-building-blocks |
-| **Retrofitting** | Undocumented codebase | architecture-document-existing (→ architecture-runtime, architecture-building-blocks for delegation) |
+| **Retrofitting** | Undocumented codebase | architecture-document-existing (→ architecture-runtime, architecture-building-blocks, architecture-deployment, architecture-quality for delegation) |
 | **Evolving** | Change or extend | architecture-decisions → architecture-risks-debt (as needed) |
 
-Also: architecture-runtime (flows), architecture-crosscutting (rules), architecture-glossary (terms).
+Also: architecture-runtime (flows), architecture-deployment (topology, compose/infra), architecture-quality (NFR scenarios), architecture-crosscutting (rules), architecture-glossary (terms).
 
 ### When to trigger architecture
 

--- a/skills/SKILL_TREE.md
+++ b/skills/SKILL_TREE.md
@@ -486,7 +486,7 @@ Guides visual/GUI-based agent development with n8n, Flowise, and LangFlow. Cover
 
 ## Implementation Status
 
-*Inventory: **108** `SKILL.md` files under `pkuppens/skills/` (2026-05-17, #26: `architecture-deployment`, `architecture-quality`; prior #57, #59–#65, #67, #84). See [audit-results.md](../docs/skills/audit-results.md) for how to regenerate the list.*
+*Inventory: **109** `SKILL.md` files under `pkuppens/skills/` (2026-05-23, #26: `architecture-deployment`, `architecture-quality`; #97: `issue-coding`; prior #57, #59–#65, #67, #84). See [audit-results.md](../docs/skills/audit-results.md) for how to regenerate the list.*
 
 | Skill | Status |
 | skill-creation | ✅ implemented |

--- a/skills/SKILL_TREE.md
+++ b/skills/SKILL_TREE.md
@@ -486,12 +486,12 @@ Guides visual/GUI-based agent development with n8n, Flowise, and LangFlow. Cover
 
 ## Implementation Status
 
-*Inventory: **106** `SKILL.md` files under `pkuppens/skills/` (2026-05-12, #57, #59–#65, #67, #84). See [audit-results.md](../docs/skills/audit-results.md) for how to regenerate the list.*
+*Inventory: **108** `SKILL.md` files under `pkuppens/skills/` (2026-05-17, #26: `architecture-deployment`, `architecture-quality`; prior #57, #59–#65, #67, #84). See [audit-results.md](../docs/skills/audit-results.md) for how to regenerate the list.*
 
 | Skill | Status |
 | skill-creation | ✅ implemented |
 | issue-workflow (5.x) | ✅ implemented |
-| architecture (3.x) | ✅ implemented (#28: sir-read-a-lot arch skills merged) |
+| architecture (3.x) | ✅ implemented (#28; #26: `architecture-deployment` 3.5, `architecture-quality` 3.8) |
 | design (4.1) | ✅ implemented |
 | implementation (7.1) | ✅ implemented |
 | validation (8.1) | ✅ implemented |

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -71,7 +71,9 @@ Output follows the sub-skill(s) invoked. Orchestrator output summarizes mode and
 | Sub-skill | When |
 |-----------|------|
 | [architecture-runtime](architecture-runtime/SKILL.md) | Document technical execution paths, sequences |
+| [architecture-deployment](architecture-deployment/SKILL.md) | Document deployment topology (arc42 §7) |
 | [architecture-crosscutting](architecture-crosscutting/SKILL.md) | Define dependency rules, layer boundaries, architecture tests |
+| [architecture-quality](architecture-quality/SKILL.md) | Quality tree and scenarios (arc42 §10) |
 | [architecture-glossary](architecture-glossary/SKILL.md) | Maintain ubiquitous language, resolve terminology |
 
 These can be invoked from architecture-document-existing during retrofitting, or directly when needed.

--- a/skills/architecture/architecture-deployment/SKILL.md
+++ b/skills/architecture/architecture-deployment/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: architecture-deployment
+description: "Documents deployment topology: infrastructure, containers, and mapping of software to infra (arc42 §7). Use when describing how the system is deployed or updating deployment docs."
+---
+
+# Architecture Deployment
+
+Documents how software is mapped to infrastructure. Aligns with arc42 §7 (deployment view).
+
+## When to use
+
+- Greenfield: first deployment topology for a new system
+- New environments (staging, DR) or hosting changes
+- Before release work — align with [deployment-release](../../deployment/deployment-release/SKILL.md)
+
+## Outputs
+
+- `docs/architecture/07-deployment.md` — deployment view narrative
+- `docs/architecture/diagrams/deployment.mmd` — optional topology diagram (Mermaid)
+
+## Instructions
+
+1. **Inventory runtime units** — services, workers, databases, queues, object storage, CDN.
+2. **Map to infrastructure** — hosts, regions, clusters, serverless, managed services.
+3. **Document environments** — dev, staging, production; what differs (scale, secrets, URLs).
+4. **Show communication** — ingress, egress, VPC/subnet boundaries, TLS termination.
+5. **Link building blocks** — each deployable maps to a component from §5.
+6. **Note operational hooks** — health checks, config sources, secrets management (no secret values in docs).
+
+## Deployment doc format
+
+```markdown
+# Deployment (arc42 §7)
+
+## Environments
+| Environment | Purpose | Hosting |
+|-------------|---------|---------|
+
+## Topology
+[Diagram or bullet list: nodes and connections]
+
+## Mapping: software → infrastructure
+| Component | Artifact | Runtime | Notes |
+
+## Cross-cutting deployment concerns
+- Scaling, backups, DR, observability endpoints
+```
+
+## Integration
+
+- Complements [architecture-building-blocks](../architecture-building-blocks/SKILL.md) (what) with where/how it runs.
+- [deployment-build](../../deployment/deployment-build/SKILL.md) and [deployment-release](../../deployment/deployment-release/SKILL.md) execute releases; this skill documents the target topology.
+- Parent: [architecture](../SKILL.md).

--- a/skills/architecture/architecture-quality/SKILL.md
+++ b/skills/architecture/architecture-quality/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: architecture-quality
+description: "Documents quality tree and quality scenarios; maps to requirements (arc42 §10). Use when defining non-functional goals, scenarios, or acceptance of quality attributes."
+---
+
+# Architecture Quality
+
+Documents quality goals as scenarios the architecture must satisfy. Aligns with arc42 §10 (quality requirements).
+
+## When to use
+
+- Defining or refining non-functional requirements (performance, security, availability)
+- Before major design decisions — test options against quality scenarios
+- Pairing with [requirements-goals](../../requirements/requirements-goals/SKILL.md) for top-level goals
+
+## Outputs
+
+- `docs/architecture/10-quality.md` — quality tree and scenarios
+- Trace links to requirements and ADRs where decisions affect quality
+
+## Instructions
+
+1. **List quality attributes** — e.g. performance, security, maintainability, usability, compliance.
+2. **Build a quality tree** — refine each attribute into measurable sub-topics.
+3. **Write scenarios** — stimulus / environment / artefact / response / measure (ISO 25010 style).
+4. **Map to requirements** — link scenario IDs to requirement or issue IDs.
+5. **Record architecture tactics** — caching, redundancy, authZ — without duplicating full ADR text (link to §9).
+
+## Quality scenario format
+
+```markdown
+# Quality (arc42 §10)
+
+## Quality tree
+- Performance
+  - API latency under load
+  - Batch throughput
+
+## Scenarios
+| ID | Attribute | Stimulus | Response | Measure |
+|----|-----------|----------|----------|---------|
+| QS-01 | Performance | 100 RPS sustained | p95 < 200ms | load test |
+```
+
+## Integration
+
+- Informs [design](../../design/SKILL.md) and [quality-gate](../../quality-gate/SKILL.md) checks.
+- [architecture-risks-debt](../architecture-risks-debt/SKILL.md) when scenarios reveal unacceptable risk.
+- Parent: [architecture](../SKILL.md).


### PR DESCRIPTION
## Summary

- Add `scripts/validate-skill-frontmatter.sh` that validates all `SKILL.md` files against the agentskills.io specification: frontmatter existence, `name` (regex, length, dir-match, no consecutive hyphens), `description` (presence, length), and `compatibility` (length if present).
- Wire the script into CI (`validate-skills.yml`) as a step before the existing `skills-ref` reference checker, providing defense-in-depth without replacing the external tool (per ADR 001).
- Add a local `pre-commit` hook so validation runs on every commit touching `skills/**/SKILL.md`.
- Also includes prior branch commits: arc42 deployment/quality skills and SKILL_TREE inventory fix from #26.

Closes #95

## Test plan

- [x] Script passes all 109 skills locally
- [x] Pre-commit hook passes
- [ ] CI workflow runs the self-owned step and passes on this PR
- [ ] Verify script detects invalid frontmatter (e.g. missing name, name > 64 chars, dir mismatch)

Made with [Cursor](https://cursor.com)