### PR TITLE
#101: bootstrap skill-benchmark + workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ From ASML metrology and Philips Healthcare to CART-Tech and Nemo Healthcare—20
 
 This repo hosts a unified skills library for Cursor, Claude, and Codex: arc42-aligned workflows from ideation to deployment. Includes agent rules, skills, and workflow definitions. See [skills/SKILL_TREE.md](skills/SKILL_TREE.md) for the full index.
 
+## Software Development Discipline
+
+This repo follows a platform-agnostic development workflow documented in [docs/workflow/README.md](docs/workflow/README.md). Platform-specific details reference it as the canonical source of truth:
+
+- [GitHub](docs/workflow/github.md)
+- [Azure DevOps](docs/workflow/azure-devops.md)
+
 ## Current Projects
 
 ### 🔒 On-Premise RAG System

--- a/docs/workflow/README.md
+++ b/docs/workflow/README.md
@@ -1,0 +1,185 @@
+# Software Development Discipline (Platform-Agnostic)
+
+This document is the single, platform-independent source of truth for how this repository is developed and reviewed. It is intentionally written without naming any specific Git hosting provider or CI product.
+
+Platform-specific guides (e.g., command names, exact CI configuration locations) should reference this doc as the canonical workflow.
+
+---
+
+## 1) Issue discipline
+
+Every unit of work starts as an issue that is specific enough for an implementer (human or agent) to execute without extra back-and-forth.
+
+### Title format
+
+Use: `[TYPE]: verb + object`
+
+Common types in this repository: `FEAT`, `TASK`, `BUG`, `STORY`, `EPIC` (and optionally `CHORE`).
+
+### Required sections (minimum)
+
+- **Goal**: one sentence describing the outcome and why it matters
+- **Tasks**: a short, numbered list of concrete steps
+- **Acceptance Criteria**: copy-pastable checks, as measurable outcomes
+- **Context**: dependencies, links, constraints, and any “why” that would otherwise be guessed
+- **Out of Scope**: what will not be addressed in this work item
+- **Estimate**: T-shirt size (S/M/L) or a short time range
+- **Metadata**: ownership/assignee and any repo conventions (labels, milestones, etc.)
+
+### Acceptance Criteria guidance
+
+Acceptance criteria must be testable. Prefer:
+
+- Measurable outcomes (what changes, where to observe it)
+- Explicit validation steps (commands, URLs, file paths, or UI checks)
+- A clear definition of “done” that does not include “it looks OK”
+
+### Ownership
+
+An issue should have an explicit owner (assignee). If multiple stakeholders are involved, link them in **Context** rather than leaving the implementer guessing.
+
+---
+
+## 2) Branching
+
+### One branch per issue
+
+Create a feature branch for each issue. This keeps review scope tight and prevents cross-talk between unrelated changes.
+
+### Branch prefixes
+
+Use consistent prefixes:
+
+- `feature/NNN-description`
+- `hotfix/NNN-description`
+- `chore/NNN-description`
+- `epic/NNN-description`
+
+Where `NNN` matches the issue number that spawned the branch.
+
+### No direct commits to default branch
+
+Do not push changes directly to `main`/`master` (or any protected default branch). All changes must go through the pull/merge request workflow.
+
+---
+
+## 3) Commit conventions
+
+Commits complement the issue by preserving an auditable history.
+
+### Conventional commits + issue linking
+
+Use `type: description` (e.g. `feat: add workflow doc`) and include a reference to the issue in every commit message (e.g. `#NNN`).
+
+### Explain the intent (what + why)
+
+Write commit messages that make the reason for the change easy to understand later:
+
+- **What** changed
+- **Why** it needed to exist
+
+Avoid committing without context; if you need a long explanation, put it in the issue description or PR notes instead.
+
+---
+
+## 4) Pull/merge request workflow
+
+All code and doc changes must be proposed via a pull/merge request and reviewed before merging.
+
+### PR description structure
+
+Use a structured PR description that mirrors the issue discipline:
+
+- Summary (what and why)
+- Changes (what files/areas were touched)
+- Issue link(s) (which issues this PR closes or relates to)
+- Validation evidence (what checks were run and what the result was)
+
+### Review before merge
+
+Do not merge until:
+
+- The PR review is complete
+- Quality gates have passed (lint/format/test/security as applicable)
+- Any open “Changes requested” items are resolved
+
+---
+
+## 5) Code review checklist
+
+Reviews should focus on correctness, maintainability, and safety.
+
+Use a checklist like this:
+
+- Imports and structure: no unnecessary coupling, no circular dependencies
+- Naming and intent: clear and consistent with surrounding code
+- Tests: changes are covered where risk is introduced
+- Security and privacy: no sensitive data leakage, safe handling of secrets
+- Documentation: new behavior is documented, and links are correct
+
+### Severity model
+
+Treat findings as one of:
+
+- Ready to merge (no blockers)
+- Changes requested (must fix before merge)
+- Blocked (requires discussion, design decision, or external access)
+
+---
+
+## 6) Quality gates
+
+Quality gates prevent avoidable regressions and enforce a consistent baseline.
+
+Run these before every commit and again before merging:
+
+- Linting
+- Formatting
+- Type checking (if configured)
+- Unit/integration tests
+- Security/static checks (as applicable)
+
+Never bypass quality gates with a “skip checks” workflow. If a check needs an exception, document the exemption explicitly in the PR notes and track the reason in the issue.
+
+---
+
+## 7) CI/CD principles
+
+The CI/CD pipeline should provide confidence in both correctness and deployability.
+
+### Required pipeline behavior
+
+- PR validation runs checks before merge
+- Merge triggers a staged deployment path (staging before production)
+- Rollback is possible if a deploy fails or a regression is detected
+- Smoke tests run after deployment to confirm basic health
+
+### Evidence over assumptions
+
+Do not claim “release is safe” without evidence from checks and smoke tests.
+
+---
+
+## 8) Post-merge cleanup
+
+After merging, keep the repo healthy and reduce operational noise.
+
+### Cleanup tasks
+
+- Prune or delete local branches that are no longer needed
+- Clean CI run history as appropriate for the repository’s conventions
+- Keep scratch directories tidy (`tmp/`), and ensure no accidental artifacts were committed
+
+---
+
+## 9) Verification
+
+Verification is the discipline of proving that “done” is actually true.
+
+Before stating that work is complete:
+
+- Run the relevant validation checks
+- Report what you ran and what the result was
+- Prefer exact commands and observable outcomes over vague statements
+
+If something fails, update the issue/PR with the failure evidence and the fix plan.

--- a/docs/workflow/README.md
+++ b/docs/workflow/README.md
@@ -1,14 +1,33 @@
 # Software Development Discipline (Platform-Agnostic)
 
-This document is the single, platform-independent source of truth for how this repository is developed and reviewed. It is intentionally written without naming any specific Git hosting provider or CI product.
+This document is the single, platform-independent source of truth for how this repository is developed and reviewed. Procedures here avoid binding to one vendor’s commands or config layout.
 
-Platform-specific guides (e.g., command names, exact CI configuration locations) should reference this doc as the canonical workflow.
+Platform-specific guides (command names, exact CI file locations) live beside this doc:
+
+- [GitHub mapping](github.md)
+- [Azure DevOps mapping](azure-devops.md) (when available)
+
+## Scope (non-exhaustive examples)
+
+This doc applies regardless of tooling. Common mappings:
+
+| Concern | Examples (not limited to these) |
+|---------|----------------------------------|
+| Git hosting | GitHub, Azure DevOps Repos, GitLab |
+| CI/CD products | GitHub Actions, Azure Pipelines, GitLab CI |
+| Work tracking | GitHub Issues, Azure Boards, Jira |
+
+Details for a chosen stack belong in the platform guide, not here.
 
 ---
 
 ## 1) Issue discipline
 
 Every unit of work starts as an issue that is specific enough for an implementer (human or agent) to execute without extra back-and-forth.
+
+When requirements are still vague, run a structured refinement session before coding. The external [grill-with-docs](https://www.skills.sh/mattpocock/skills/grill-with-docs) skill (or equivalent workshop) helps sharpen acceptance criteria and terminology against project docs. That step is human-in-the-loop and happens **before** implementation.
+
+Refined issue text is also a good **skill-benchmark** candidate: compare baseline output vs output with issue-workflow (or grill-with-docs) skills loaded.
 
 ### Title format
 
@@ -42,9 +61,17 @@ An issue should have an explicit owner (assignee). If multiple stakeholders are 
 
 ## 2) Branching
 
-### One branch per issue
+### Branch per unit of work (with flexibility)
 
-Create a feature branch for each issue. This keeps review scope tight and prevents cross-talk between unrelated changes.
+Default: one branch per issue so review scope stays tight.
+
+Allowed variations:
+
+- **Epic branch** (`epic/NNN-description`) for coordinated work across several child issues; merge only when the epic’s acceptance criteria are met.
+- **Feature branch for a parent issue** when child issues land in the same PR sequence; still link every commit to the relevant `#NNN`.
+- **Sub-issues** keep their own issue numbers; branch name should reflect the issue you are implementing now, not only the parent epic.
+
+Pick the smallest branch scope that still matches how reviewers will validate the change.
 
 ### Branch prefixes
 
@@ -55,7 +82,7 @@ Use consistent prefixes:
 - `chore/NNN-description`
 - `epic/NNN-description`
 
-Where `NNN` matches the issue number that spawned the branch.
+Where `NNN` is the issue number for the branch’s primary tracking item (feature, task, or epic).
 
 ### No direct commits to default branch
 
@@ -149,7 +176,8 @@ The CI/CD pipeline should provide confidence in both correctness and deployabili
 
 ### Required pipeline behavior
 
-- PR validation runs checks before merge
+- **Validation checks run on (or immediately after) PR creation** so reviewers see lint/test results alongside the diff. Examples: lint, format, unit tests, type check, security scan, markdown lint.
+- **Not every pipeline step is a validation check.** Building container images, publishing packages, or deploying to staging/production may run later (often after merge). Do not block PR review on deploy-only jobs unless the change requires them.
 - Merge triggers a staged deployment path (staging before production)
 - Rollback is possible if a deploy fails or a regression is detected
 - Smoke tests run after deployment to confirm basic health

--- a/docs/workflow/github.md
+++ b/docs/workflow/github.md
@@ -1,0 +1,167 @@
+# GitHub Workflow Mapping (Platform-Specific)
+
+This guide maps the platform-agnostic workflow in [`docs/workflow/README.md`](README.md) to concrete GitHub conventions and commands used in this repository.
+
+When in doubt, follow the agnostic workflow, then apply the matching GitHub tool examples below.
+
+---
+
+## Mapping: platform-agnostic areas to GitHub specifics
+
+| Workflow area | GitHub tool | Existing skill(s) |
+|---|---|---|
+| Issue discipline | `gh issue create/view/edit` | [`issue-workflow`](../../skills/issue-workflow/SKILL.md) |
+| Duplicate check | `gh issue list` + search | [`issue-check-duplicates`](../../skills/issue-workflow/issue-check-duplicates/SKILL.md) |
+| Metadata | labels, milestones, `--assignee @me` | [`issue-metadata`](../../skills/issue-workflow/issue-metadata/SKILL.md) |
+| Bulk creation | `gh issue create` in a loop | [`issue-gh-bulk-scratch`](../../skills/issue-workflow/issue-gh-bulk-scratch/SKILL.md) |
+| Branching | `git checkout -b feature/NNN-...` | [`plan-branch-strategy`](../../skills/plan-branch-strategy/SKILL.md) |
+| Commit linking | `#NNN` in commit message | [`integration-commit`](../../skills/integration/integration-commit/SKILL.md) |
+| PR creation | `gh pr create --assignee @me` | [`integration-pr`](../../skills/integration/integration-pr/SKILL.md) |
+| PR merge | `gh pr merge --squash --delete-branch` | [`integration-merge`](../../skills/integration/integration-merge/SKILL.md) |
+| Code review | PR review workflow on GitHub | [`code-review`](../../skills/code-review/SKILL.md) |
+| Quality gate | pre-commit + GitHub Actions checks | [`quality-gate`](../../skills/quality-gate/SKILL.md) |
+| CI/CD | `.github/workflows/` validations + deploy steps | [`deployment`](../../skills/deployment/SKILL.md) + [`deployment-release`](../../skills/deployment/deployment-release/SKILL.md) |
+| Cleanup | `gh run delete`, branch pruning | [`maintenance-cleanup`](../../skills/maintenance/maintenance-cleanup/SKILL.md), [`branch-cleanup-after-pr`](../../skills/branch-cleanup-after-pr/SKILL.md) |
+| Monitoring | Actions logs as evidence | [`operations-monitoring`](../../skills/operations/operations-monitoring/SKILL.md) |
+
+---
+
+## Issue lifecycle (GitHub commands)
+
+### Create / view / edit an issue
+
+- Create:
+
+```bash
+gh issue create \
+  --title "[FEAT]: verb + object #NNN" \
+  --body "## Goal\n...\n\n## Acceptance Criteria\n- [ ] ...\n"
+```
+
+- View:
+
+```bash
+gh issue view NNN
+```
+
+- Edit (example: add assignee / update body):
+
+```bash
+gh issue edit NNN --add-assignee @me
+```
+
+### Duplicate check
+
+Use a targeted list/search before implementing anything new:
+
+```bash
+gh issue list --state open --search "\"[FEAT]\" label:enhancement"
+gh issue list --state closed --search "duplicate query terms"
+```
+
+This aligns with [`issue-check-duplicates`](../../skills/issue-workflow/issue-check-duplicates/SKILL.md).
+
+---
+
+## Branching and commits
+
+### Branch per issue
+
+Use the issue number prefix so later automation can link work:
+
+```bash
+git checkout -b feature/NNN-short-description
+```
+
+This aligns with [`plan-branch-strategy`](../../skills/plan-branch-strategy/SKILL.md).
+
+### Commit messages link back to issues
+
+Every commit should include `#NNN` so history remains navigable:
+
+```text
+#123: feat: add workflow docs
+```
+
+This aligns with [`integration-commit`](../../skills/integration/integration-commit/SKILL.md).
+
+---
+
+## Pull requests and merge flow
+
+### Create PR
+
+```bash
+gh pr create --assignee @me --title "feat: ..." --body "Summary...\n\nCloses #NNN"
+```
+
+This aligns with [`integration-pr`](../../skills/integration/integration-pr/SKILL.md).
+
+### Code review
+
+Use the PR review checklist defined in [`code-review`](../../skills/code-review/SKILL.md). When review reveals risk or missing acceptance coverage, ensure the PR is blocked until addressed.
+
+### Merge PR
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+This aligns with [`integration-merge`](../../skills/integration/integration-merge/SKILL.md).
+
+---
+
+## Quality gate and CI/CD on GitHub
+
+### Quality gate sequence
+
+The agnostic workflow says: “run checks before claiming done”. On GitHub, this typically means:
+
+1. Local: pre-commit (lint/format/etc.)
+2. PR: GitHub Actions checks
+3. Evidence: record what ran and what passed
+
+This aligns with [`quality-gate`](../../skills/quality-gate/SKILL.md).
+
+### CI/CD documentation pattern
+
+Use a `CI/CD expectations` table in project docs (e.g. root `CLAUDE.md`) so the review can verify that the repository actually runs what it claims.
+
+Even without a specialised CI-orchestration skill, the same expectations table helps reviewers check that CI/CD behavior matches the project contract.
+
+---
+
+## Post-merge cleanup and monitoring
+
+### Cleanup
+
+After merge:
+
+- prune local branches (`git fetch --prune` + delete merged branches)
+- clean CI run history as appropriate
+
+The skills to follow are [`maintenance-cleanup`](../../skills/maintenance/maintenance-cleanup/SKILL.md) and [`branch-cleanup-after-pr`](../../skills/branch-cleanup-after-pr/SKILL.md).
+
+Example run cleanup pattern:
+
+```bash
+gh run list --state completed --limit 100
+gh run delete <run-id>
+```
+
+### Monitoring evidence
+
+Monitoring is done by reviewing Actions logs and status, then escalating to incident handling when needed. See [`operations-monitoring`](../../skills/operations/operations-monitoring/SKILL.md).
+
+---
+
+## Human-in-the-loop pause (when using agents)
+
+The workflow can include an optional maintainer pause before coding. The default guidance is:
+
+From [`skills/COOPERATION.md`](../../skills/COOPERATION.md):
+
+```text
+Human-in-the-loop pause: After `issue-workflow` and `plan`, a maintainer may review the issue before coding.
+Invoke issue-coding only after that review, or when the issue has execution:ai-ok and an explicit go-ahead.
+```

--- a/tools/skill-benchmark/.env.example
+++ b/tools/skill-benchmark/.env.example
@@ -1,0 +1,15 @@
+# Copy to .env and adjust for your machine (.env is gitignored).
+# Run commands from tools/skill-benchmark/ so this file is found.
+
+# Ollama (OpenAI-compatible API)
+OPENAI_API_KEY=ollama
+BENCHMARK_LLM_BASE_URL=http://localhost:11434/v1
+BENCHMARK_LLM_MODEL=qwen2.5-coder:14b
+
+# Optional: use a stronger model for scoring
+BENCHMARK_SCORER_BASE_URL=http://localhost:11434/v1
+BENCHMARK_SCORER_MODEL=qwen2.5-coder:14b
+
+# Output paths (repo-relative from workspace root when run from monorepo)
+# BENCHMARK_TMP_DIR=tmp/skills/benchmark
+# BENCHMARK_DOCS_DIR=docs/skills/benchmark

--- a/tools/skill-benchmark/.gitignore
+++ b/tools/skill-benchmark/.gitignore
@@ -1,0 +1,12 @@
+.venv/
+.env
+__pycache__/
+*.pyc
+.ruff_cache/
+.pytest_cache/
+.mypy_cache/
+*.egg-info/
+
+# Local scratch (benchmark outputs, intermediate evidence)
+tmp/
+

--- a/tools/skill-benchmark/README.md
+++ b/tools/skill-benchmark/README.md
@@ -64,7 +64,15 @@ At this stage, command bodies are intentionally placeholders and will raise a "N
 
 ## Configuration
 
-Environment variables are parsed by `src/skill_benchmark/config.py`.
+Settings load from **environment variables** and from a **`.env` file** in `tools/skill-benchmark/` (gitignored). Copy `.env.example` to `.env` for local Ollama runs.
+
+```bash
+cd tools/skill-benchmark
+cp .env.example .env
+# edit .env — model names, base URL, API key
+```
+
+See `src/skill_benchmark/README.md` for the end-to-end benchmark workflow and example task.
 
 ### Core LLM settings
 

--- a/tools/skill-benchmark/README.md
+++ b/tools/skill-benchmark/README.md
@@ -1,0 +1,114 @@
+# skill-benchmark
+
+Skill benchmark is a small Python toolset to measure whether a skill improves agent output quality.
+
+The benchmark compares two runs of the same task:
+
+1. **Baseline**: run without the skill content
+2. **With skill**: run with the skill content
+
+This makes skill quality visible and discussable with evidence instead of opinion.
+
+## Why this exists
+
+This repo has many skills. Without a benchmark flow, it is hard to answer questions like:
+
+- "Did this skill update actually help?"
+- "Which skills have the biggest impact?"
+- "Did a refactor reduce quality?"
+
+The benchmark package helps generate repeatable evidence so pull requests can include concrete results.
+
+## User stories
+
+- As a skill author, I want to compare baseline and with-skill output, so I can prove my skill adds value.
+- As a reviewer, I want to see structured benchmark evidence, so I can approve changes with more confidence.
+- As a maintainer, I want a repeatable benchmark workflow, so regressions are detected early.
+- As a contributor, I want clear extension points, so I can add new tasks, skills, and scoring logic safely.
+
+## Current scope (this bootstrap step)
+
+This first version provides the foundation:
+
+- Configuration loading (`BenchmarkConfig`)
+- OpenAI-compatible provider wrapper (`LLMProvider`)
+- CLI skeleton for future commands (`list-tasks`, `list-skills`, `run`)
+- Unit tests for config and provider behavior
+
+Follow-up issues add loaders, scoring, reports, and full orchestration.
+
+## Quick start
+
+### 1) Setup
+
+```bash
+cd tools/skill-benchmark
+uv sync
+```
+
+### 2) Run checks
+
+```bash
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+```
+
+### 3) Explore the CLI skeleton
+
+```bash
+uv run python -m skill_benchmark.cli --help
+```
+
+At this stage, command bodies are intentionally placeholders and will raise a "Not implemented yet" message.
+
+## Configuration
+
+Environment variables are parsed by `src/skill_benchmark/config.py`.
+
+### Core LLM settings
+
+- `OPENAI_API_KEY`: API key for OpenAI-compatible endpoints
+- `BENCHMARK_LLM_BASE_URL`: base URL for generation model endpoint
+- `BENCHMARK_LLM_MODEL`: model name for generation calls
+- `BENCHMARK_SCORER_BASE_URL`: base URL for scorer model endpoint
+- `BENCHMARK_SCORER_MODEL`: model name for scorer calls
+
+### Paths
+
+- `BENCHMARK_TMP_DIR`: scratch output location (default: `tmp/skills/benchmark`)
+- `BENCHMARK_DOCS_DIR`: report output location (default: `docs/skills/benchmark`)
+
+### Example (PowerShell)
+
+```powershell
+$env:OPENAI_API_KEY="your-key"
+$env:BENCHMARK_LLM_BASE_URL="http://localhost:11434/v1"
+$env:BENCHMARK_LLM_MODEL="qwen2.5-coder:14b"
+```
+
+## How to extend or change
+
+### Add a new benchmark task
+
+1. Add a task markdown file under `docs/skills/benchmark/tasks/`
+2. Keep task prompt and expected coverage explicit
+3. Add loader tests once loader implementation is added
+
+### Add a new provider behavior
+
+1. Extend `LLMProvider` in `src/skill_benchmark/provider.py`
+2. Keep API surface backward compatible (`complete(...) -> LLMResponse`)
+3. Add tests in `tests/test_provider.py`
+
+### Add new CLI command behavior
+
+1. Implement command flow in `src/skill_benchmark/cli.py`
+2. Keep command help text user-focused
+3. Add command tests and README usage examples
+
+## Design notes
+
+- This package uses OpenAI-compatible APIs, which allows local and cloud providers behind one interface.
+- Provider injection in tests avoids real API calls and keeps unit tests fast.
+- Configuration uses environment variables to keep secrets out of code and out of git history.

--- a/tools/skill-benchmark/pyproject.toml
+++ b/tools/skill-benchmark/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "skill-benchmark"
+version = "0.1.0"
+description = "Tools to benchmark AI skills (baseline vs with-skill) and generate evidence reports."
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+  "openai",
+  "pydantic-settings",
+  "click",
+  "pytest",
+  "pytest-asyncio",
+  "ruff",
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+

--- a/tools/skill-benchmark/src/skill_benchmark/README.md
+++ b/tools/skill-benchmark/src/skill_benchmark/README.md
@@ -1,0 +1,54 @@
+# skill_benchmark package
+
+## Purpose
+
+This package runs **skill benchmarks**: the same task is executed twice so you can compare quality with and without skill guidance.
+
+## Goal
+
+Produce evidence that a skill improves output (structure, completeness, correctness) instead of relying on subjective review.
+
+## End-to-end workflow (target)
+
+When fully wired (#102–#104), a benchmark run looks like this:
+
+```text
+1. Pick a task prompt (e.g. from docs/skills/benchmark/tasks/)
+2. Pick a skill to test (e.g. issue-workflow)
+3. Generate baseline output (prompt only, no skill text)
+4. Generate with-skill output (same prompt + SKILL.md content)
+5. Score both outputs independently (4 dimensions, 1–5 each)
+6. Write a markdown report with verdict and deltas
+```
+
+Outputs:
+
+- Scratch: `tmp/skills/benchmark/<skill-name>/output-baseline.md`, `output-with-skill.md`
+- Report: `docs/skills/benchmark/<skill-name>/report.md`
+
+## Example task (markdown only, no GitHub issue created)
+
+**Prompt:** “Create a markdown specification for role-based access control (RBAC) for a web application.”
+
+| Run | What the agent gets | Expected difference |
+|-----|---------------------|---------------------|
+| Baseline | Task prompt only | Generic RBAC doc; may miss sections |
+| With skill | Same prompt + `issue-workflow` / issue-acceptance-criteria skill | Clear sections: goal, tasks, acceptance criteria, out of scope, estimate |
+
+We compare markdown artefacts only. **Do not** call `gh issue create` during the benchmark.
+
+A future task file may formalize this as `rbac-spec.md` under `docs/skills/benchmark/tasks/`.
+
+## Modules in this directory
+
+| Module | Role |
+|--------|------|
+| `config.py` | Settings from environment and `.env` (Ollama, models, paths) |
+| `provider.py` | OpenAI-compatible LLM calls |
+| `cli.py` | User commands (`run`, `list-tasks`, `list-skills`) — scaffold in #101 |
+
+## Bootstrap status (#101)
+
+Loaders, generator, scorer, and orchestrator are added in follow-up issues. This directory already provides config + provider + CLI skeleton.
+
+See also the package README at `tools/skill-benchmark/README.md`.

--- a/tools/skill-benchmark/src/skill_benchmark/__init__.py
+++ b/tools/skill-benchmark/src/skill_benchmark/__init__.py
@@ -1,0 +1,6 @@
+"""skill_benchmark: configuration and LLM provider wrapper for benchmark runs."""
+
+from .config import BenchmarkConfig
+from .provider import LLMProvider, LLMResponse
+
+__all__ = ["BenchmarkConfig", "LLMProvider", "LLMResponse"]

--- a/tools/skill-benchmark/src/skill_benchmark/cli.py
+++ b/tools/skill-benchmark/src/skill_benchmark/cli.py
@@ -1,0 +1,52 @@
+"""CLI entry points for skill benchmark workflows.
+
+Commands are intentionally scaffolded in this bootstrap stage. Later issues
+add task loading, generation, scoring, and report creation behavior.
+"""
+
+import click
+
+
+@click.group()
+def cli() -> None:
+    """Skill benchmark harness CLI.
+
+    This is a bootstrap skeleton; sub-commands will be implemented in follow-up
+    benchmark sub-issues (#102–#104).
+    """
+
+
+@cli.command("list-tasks")
+def list_tasks() -> None:
+    """List available benchmark tasks.
+
+    Placeholder implementation (loaders and tasks are added in #102).
+    """
+
+    raise click.ClickException("Not implemented yet.")
+
+
+@cli.command("list-skills")
+def list_skills() -> None:
+    """List available skills that can be benchmarked.
+
+    Placeholder implementation (task/skill loaders are added in #102).
+    """
+
+    raise click.ClickException("Not implemented yet.")
+
+
+@cli.command("run")
+@click.argument("skill_name", required=True)
+@click.argument("task_name", required=True)
+def run_benchmark(skill_name: str, task_name: str) -> None:
+    """Run a full benchmark (baseline vs with-skill).
+
+    Placeholder implementation; orchestration and execution are added in #104.
+    """
+
+    raise click.ClickException(f"Not implemented yet (skill={skill_name}, task={task_name}).")
+
+
+if __name__ == "__main__":
+    cli()

--- a/tools/skill-benchmark/src/skill_benchmark/cli.py
+++ b/tools/skill-benchmark/src/skill_benchmark/cli.py
@@ -1,7 +1,15 @@
-"""CLI entry points for skill benchmark workflows.
+"""CLI for the skill benchmark harness.
 
-Commands are intentionally scaffolded in this bootstrap stage. Later issues
-add task loading, generation, scoring, and report creation behavior.
+Purpose:
+    Give maintainers simple commands to list tasks/skills and run benchmarks.
+
+What it helps with:
+    - Discover which benchmark tasks and skills exist
+    - Run baseline vs with-skill comparisons (once #104 lands)
+    - Produce evidence files for pull requests
+
+This module is a thin wrapper around Click. You do not need to know Click internals
+to use it: run `uv run python -m skill_benchmark.cli --help`.
 """
 
 import click
@@ -9,18 +17,37 @@ import click
 
 @click.group()
 def cli() -> None:
-    """Skill benchmark harness CLI.
+    """Skill benchmark harness — compare agent output with and without skills.
 
-    This is a bootstrap skeleton; sub-commands will be implemented in follow-up
-    benchmark sub-issues (#102–#104).
+    Goal:
+        Measure whether a skill improves task output quality using repeatable runs.
+
+    What you can do (today vs planned):
+        - Today (#101): show help; sub-commands are placeholders
+        - #102: list tasks and skills from the repo
+        - #104: run full benchmark and write reports
+
+    Run from: tools/skill-benchmark/
     """
 
 
 @cli.command("list-tasks")
 def list_tasks() -> None:
-    """List available benchmark tasks.
+    """List benchmark task prompts available under docs/skills/benchmark/tasks/.
 
-    Placeholder implementation (loaders and tasks are added in #102).
+    Purpose:
+        Show which tasks you can run against a skill.
+
+    Planned behavior (#102):
+        Print one task name per line (e.g. issue-creation, rbac-spec).
+
+    Examples (expected once implemented):
+
+        $ uv run python -m skill_benchmark.cli list-tasks
+        issue-creation
+        rbac-spec
+
+    Exit code: 0 on success.
     """
 
     raise click.ClickException("Not implemented yet.")
@@ -28,9 +55,21 @@ def list_tasks() -> None:
 
 @cli.command("list-skills")
 def list_skills() -> None:
-    """List available skills that can be benchmarked.
+    """List skills that can be benchmarked from the skills/ tree.
 
-    Placeholder implementation (task/skill loaders are added in #102).
+    Purpose:
+        Show skill directory names you can pass to `run`.
+
+    Planned behavior (#102):
+        Discover directories containing SKILL.md under skills/.
+
+    Examples (expected once implemented):
+
+        $ uv run python -m skill_benchmark.cli list-skills
+        issue-workflow
+        deployment-release
+
+    Exit code: 0 on success.
     """
 
     raise click.ClickException("Not implemented yet.")
@@ -40,9 +79,32 @@ def list_skills() -> None:
 @click.argument("skill_name", required=True)
 @click.argument("task_name", required=True)
 def run_benchmark(skill_name: str, task_name: str) -> None:
-    """Run a full benchmark (baseline vs with-skill).
+    """Run one full benchmark: baseline and with-skill, then score and report.
 
-    Placeholder implementation; orchestration and execution are added in #104.
+    Purpose:
+        Produce comparable evidence for a single skill on a single task.
+
+    Planned behavior (#104):
+        1. Load task prompt and skill SKILL.md
+        2. Call LLM twice (isolated contexts)
+        3. Score each output
+        4. Write tmp outputs and docs/skills/benchmark/<skill>/report.md
+
+    Examples (expected once implemented):
+
+        $ uv run python -m skill_benchmark.cli run issue-workflow issue-creation
+
+    Expected console output (summary):
+        - Paths to output-baseline.md and output-with-skill.md
+        - Path to report.md
+        - Verdict: significant improvement | marginal | no improvement
+
+    Expected artefacts:
+        - tmp/skills/benchmark/issue-workflow/output-baseline.md
+        - tmp/skills/benchmark/issue-workflow/output-with-skill.md
+        - docs/skills/benchmark/issue-workflow/report.md
+
+    Exit code: 0 on success; non-zero if LLM or scoring fails.
     """
 
     raise click.ClickException(f"Not implemented yet (skill={skill_name}, task={task_name}).")

--- a/tools/skill-benchmark/src/skill_benchmark/config.py
+++ b/tools/skill-benchmark/src/skill_benchmark/config.py
@@ -11,13 +11,20 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class BenchmarkConfig(BaseSettings):
-    """Load benchmark configuration from environment variables.
+    """Load benchmark configuration from environment variables and `.env`.
+
+    Precedence (highest first): explicit constructor args, process environment,
+    then `.env` in the current working directory (typically `tools/skill-benchmark/`).
 
     Fields are designed to support OpenAI and OpenAI-compatible providers
     (for example local Ollama servers using the same API surface).
     """
 
-    model_config = SettingsConfigDict(extra="ignore", env_file=None)
+    model_config = SettingsConfigDict(
+        extra="ignore",
+        env_file=".env",
+        env_file_encoding="utf-8",
+    )
 
     api_key: str = Field(default="", validation_alias="OPENAI_API_KEY")
 

--- a/tools/skill-benchmark/src/skill_benchmark/config.py
+++ b/tools/skill-benchmark/src/skill_benchmark/config.py
@@ -1,0 +1,46 @@
+"""Configuration model for skill benchmark runs.
+
+This module centralizes environment-based settings so benchmark runs are
+repeatable in local and CI environments without hard-coded secrets.
+"""
+
+from pathlib import Path
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class BenchmarkConfig(BaseSettings):
+    """Load benchmark configuration from environment variables.
+
+    Fields are designed to support OpenAI and OpenAI-compatible providers
+    (for example local Ollama servers using the same API surface).
+    """
+
+    model_config = SettingsConfigDict(extra="ignore", env_file=None)
+
+    api_key: str = Field(default="", validation_alias="OPENAI_API_KEY")
+
+    llm_base_url: str = Field(
+        default="https://api.openai.com/v1",
+        validation_alias="BENCHMARK_LLM_BASE_URL",
+    )
+    llm_model: str = Field(default="gpt-4o-mini", validation_alias="BENCHMARK_LLM_MODEL")
+
+    scorer_base_url: str = Field(
+        default="https://api.openai.com/v1",
+        validation_alias="BENCHMARK_SCORER_BASE_URL",
+    )
+    scorer_model: str = Field(
+        default="gpt-4o-mini",
+        validation_alias="BENCHMARK_SCORER_MODEL",
+    )
+
+    tmp_dir: Path = Field(
+        default=Path("tmp/skills/benchmark"),
+        validation_alias="BENCHMARK_TMP_DIR",
+    )
+    docs_dir: Path = Field(
+        default=Path("docs/skills/benchmark"),
+        validation_alias="BENCHMARK_DOCS_DIR",
+    )

--- a/tools/skill-benchmark/src/skill_benchmark/provider.py
+++ b/tools/skill-benchmark/src/skill_benchmark/provider.py
@@ -1,0 +1,93 @@
+"""OpenAI-compatible provider adapter for benchmark calls.
+
+The benchmark framework needs a single interface for local and cloud model
+endpoints. This wrapper keeps call sites stable while implementations evolve.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from openai import AsyncOpenAI
+
+from .config import BenchmarkConfig
+
+
+@dataclass(frozen=True)
+class LLMResponse:
+    """A parsed LLM response plus usage metadata."""
+
+    content: str
+    model: str
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+
+
+class LLMProvider:
+    """Wrap an OpenAI-compatible async chat client."""
+
+    def __init__(self, config: BenchmarkConfig, client: Any | None = None) -> None:
+        """Create an LLM provider for benchmark runs.
+
+        Args:
+            config (BenchmarkConfig): Benchmark settings (base URL, model, API key).
+            client (Any | None): Optional pre-constructed client for tests/mocking.
+                When omitted, an `openai.AsyncOpenAI` client is created.
+
+        Raises:
+            ValueError: If `config.api_key` is empty and `client` is not provided.
+        """
+
+        if client is None and not config.api_key:
+            raise ValueError("OPENAI_API_KEY must be set (or pass an explicit client).")
+
+        self._config = config
+        self._client = client or AsyncOpenAI(api_key=config.api_key, base_url=config.llm_base_url)
+
+    async def complete(
+        self,
+        messages: list[dict[str, str]],
+        temperature: float = 0.0,
+        max_tokens: int | None = None,
+    ) -> LLMResponse:
+        """Generate a completion for chat messages.
+
+        Calls the configured OpenAI-compatible endpoint and returns the first choice
+        content plus token counts when the client provides usage metadata.
+
+        Args:
+            messages (list[dict[str, str]]): Chat messages for the completion.
+            temperature (float): Sampling temperature.
+            max_tokens (int | None): Optional token cap for the completion.
+
+        Returns:
+            LLMResponse: Parsed content, model name, and optional token usage.
+
+        Raises:
+            RuntimeError: If the response shape does not contain a usable choice/message.
+        """
+
+        resp = await self._client.chat.completions.create(
+            model=self._config.llm_model,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+
+        try:
+            choice = resp.choices[0]
+            content = (choice.message.content or "").strip()
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError("Unexpected OpenAI response shape.") from exc
+
+        usage = getattr(resp, "usage", None)
+        input_tokens = getattr(usage, "prompt_tokens", None) if usage is not None else None
+        output_tokens = getattr(usage, "completion_tokens", None) if usage is not None else None
+
+        return LLMResponse(
+            content=content,
+            model=self._config.llm_model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )

--- a/tools/skill-benchmark/tests/test_config.py
+++ b/tools/skill-benchmark/tests/test_config.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+import pytest
+
+from skill_benchmark.config import BenchmarkConfig
+
+
+def test_config_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Defaults should be stable when no environment variables are set."""
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("BENCHMARK_LLM_BASE_URL", raising=False)
+    monkeypatch.delenv("BENCHMARK_LLM_MODEL", raising=False)
+    monkeypatch.delenv("BENCHMARK_SCORER_BASE_URL", raising=False)
+    monkeypatch.delenv("BENCHMARK_SCORER_MODEL", raising=False)
+    monkeypatch.delenv("BENCHMARK_TMP_DIR", raising=False)
+    monkeypatch.delenv("BENCHMARK_DOCS_DIR", raising=False)
+
+    cfg = BenchmarkConfig()
+
+    assert cfg.api_key == ""
+    assert cfg.llm_base_url == "https://api.openai.com/v1"
+    assert cfg.llm_model == "gpt-4o-mini"
+    assert cfg.scorer_base_url == "https://api.openai.com/v1"
+    assert cfg.scorer_model == "gpt-4o-mini"
+    assert cfg.tmp_dir == Path("tmp/skills/benchmark")
+    assert cfg.docs_dir == Path("docs/skills/benchmark")
+
+
+def test_config_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Environment variables should override defaults."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+    monkeypatch.setenv("BENCHMARK_LLM_BASE_URL", "http://localhost:11434/v1")
+    monkeypatch.setenv("BENCHMARK_LLM_MODEL", "test-model")
+    monkeypatch.setenv("BENCHMARK_SCORER_BASE_URL", "http://localhost:11434/v1")
+    monkeypatch.setenv("BENCHMARK_SCORER_MODEL", "test-scorer-model")
+    monkeypatch.setenv("BENCHMARK_TMP_DIR", "tmp/skills/benchmark-test")
+    monkeypatch.setenv("BENCHMARK_DOCS_DIR", "docs/skills/benchmark-test")
+
+    cfg = BenchmarkConfig()
+
+    assert cfg.api_key == "test-api-key"
+    assert cfg.llm_base_url == "http://localhost:11434/v1"
+    assert cfg.llm_model == "test-model"
+    assert cfg.scorer_base_url == "http://localhost:11434/v1"
+    assert cfg.scorer_model == "test-scorer-model"
+    assert cfg.tmp_dir == Path("tmp/skills/benchmark-test")
+    assert cfg.docs_dir == Path("docs/skills/benchmark-test")

--- a/tools/skill-benchmark/tests/test_config.py
+++ b/tools/skill-benchmark/tests/test_config.py
@@ -16,7 +16,7 @@ def test_config_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("BENCHMARK_TMP_DIR", raising=False)
     monkeypatch.delenv("BENCHMARK_DOCS_DIR", raising=False)
 
-    cfg = BenchmarkConfig()
+    cfg = BenchmarkConfig(_env_file=None)
 
     assert cfg.api_key == ""
     assert cfg.llm_base_url == "https://api.openai.com/v1"
@@ -38,7 +38,7 @@ def test_config_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("BENCHMARK_TMP_DIR", "tmp/skills/benchmark-test")
     monkeypatch.setenv("BENCHMARK_DOCS_DIR", "docs/skills/benchmark-test")
 
-    cfg = BenchmarkConfig()
+    cfg = BenchmarkConfig(_env_file=None)
 
     assert cfg.api_key == "test-api-key"
     assert cfg.llm_base_url == "http://localhost:11434/v1"
@@ -47,3 +47,25 @@ def test_config_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
     assert cfg.scorer_model == "test-scorer-model"
     assert cfg.tmp_dir == Path("tmp/skills/benchmark-test")
     assert cfg.docs_dir == Path("docs/skills/benchmark-test")
+
+
+def test_config_loads_from_env_file(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Values in a .env file should load when no env override is set."""
+
+    monkeypatch.chdir(tmp_path)
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "OPENAI_API_KEY=from-dotenv\n"
+        "BENCHMARK_LLM_BASE_URL=http://localhost:11434/v1\n"
+        "BENCHMARK_LLM_MODEL=llama3.2\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("BENCHMARK_LLM_BASE_URL", raising=False)
+    monkeypatch.delenv("BENCHMARK_LLM_MODEL", raising=False)
+
+    cfg = BenchmarkConfig()
+
+    assert cfg.api_key == "from-dotenv"
+    assert cfg.llm_base_url == "http://localhost:11434/v1"
+    assert cfg.llm_model == "llama3.2"

--- a/tools/skill-benchmark/tests/test_provider.py
+++ b/tools/skill-benchmark/tests/test_provider.py
@@ -1,0 +1,82 @@
+import pytest
+
+from skill_benchmark.config import BenchmarkConfig
+from skill_benchmark.provider import LLMProvider
+
+
+class _StubUsage:
+    def __init__(self) -> None:
+        self.prompt_tokens = 3
+        self.completion_tokens = 5
+
+
+class _StubMessage:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _StubChoice:
+    def __init__(self, content: str) -> None:
+        self.message = _StubMessage(content=content)
+
+
+class _StubResponse:
+    def __init__(self, content: str) -> None:
+        self.choices = [_StubChoice(content=content)]
+        self.usage = _StubUsage()
+
+
+class _StubCompletions:
+    async def create(
+        self,
+        *,
+        model: str,
+        messages: list[dict[str, str]],
+        temperature: float,
+        max_tokens: int | None,
+    ):
+        assert messages == [{"role": "user", "content": "hi"}]
+        assert temperature == 0.0
+        assert model == "gpt-4o-mini"
+        assert max_tokens == 10
+        return _StubResponse(content="hello from llm")
+
+
+class _StubChat:
+    def __init__(self) -> None:
+        self.completions = _StubCompletions()
+
+
+class _StubClient:
+    def __init__(self) -> None:
+        self.chat = _StubChat()
+
+
+def test_provider_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provider init should require an API key when no client is injected."""
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    cfg = BenchmarkConfig()
+
+    with pytest.raises(ValueError, match="OPENAI_API_KEY"):
+        LLMProvider(cfg, client=None)
+
+
+@pytest.mark.asyncio
+async def test_provider_complete_parses_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provider.complete should parse the first choice and usage tokens."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+    cfg = BenchmarkConfig()
+
+    provider = LLMProvider(cfg, client=_StubClient())
+    resp = await provider.complete(
+        messages=[{"role": "user", "content": "hi"}],
+        temperature=0.0,
+        max_tokens=10,
+    )
+
+    assert resp.content == "hello from llm"
+    assert resp.model == cfg.llm_model
+    assert resp.input_tokens == 3
+    assert resp.output_tokens == 5

--- a/tools/skill-benchmark/uv.lock
+++ b/tools/skill-benchmark/uv.lock
@@ -1,0 +1,469 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/b5/55f06bb281d92fb3cc86d14e1def2bd908bb77693183e7cb1f5a3c388b0c/jiter-0.15.0.tar.gz", hash = "sha256:4251acc80e2b7c9b7b8823456ea0fceeb0734dac2df7636d3c711b38476b5a76", size = 166640, upload-time = "2026-05-19T10:09:48.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/53/4f6bddbcde3c71e56d0aa1337ec95950f3d27dd4153e25aadf0feac71751/jiter-0.15.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0e90a1c315a0226ec822d973817967f9223b7701546c8c2a7913e7ab0926294d", size = 308793, upload-time = "2026-05-19T10:07:35.25Z" },
+    { url = "https://files.pythonhosted.org/packages/01/84/c01099b59a285a1ebba64ae93f62bfa036675340fd1b0045ae65890a0442/jiter-0.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8c9004af7c8d67cce7f1aae1026fb55607f4aa600710d08ede3a3ce4aeefe7e0", size = 309570, upload-time = "2026-05-19T10:07:36.919Z" },
+    { url = "https://files.pythonhosted.org/packages/58/64/8fb7f9d45bb98190355454cd04dad8d8f27223d6bd52f83af07f637168a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c210f8b35dc6f30aafd4b4365ca89b9d1189f21ab49b8e68fa6322a847aef138", size = 336783, upload-time = "2026-05-19T10:07:38.694Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b6/f5739011d009b3a30f6a53c5240979030ba29ae46a8c67e3a15759f7c37d/jiter-0.15.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f30bae8bc1c2d613e28e5af3e8cceb09b742f1c8a8a5f839fb67afaffc03b61", size = 363555, upload-time = "2026-05-19T10:07:40.832Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/12/98a9d9f766665e8a3b6252454e17cb0c464606a28cf2fa09399b003345fa/jiter-0.15.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c60e71b6d10cfc284c9bf36bd885e8d44c46f688ce50aa91b5edd90181dea687", size = 452255, upload-time = "2026-05-19T10:07:42.62Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/d5/60f972840f79c5e7544fce567c56f1e4e50468f996baba3e78d823dd62a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ab068bce62a45aa3e7367eceaffb5dde60b7eb853be8dece45132e3d0ff4879", size = 373559, upload-time = "2026-05-19T10:07:44.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/cf/d46ef1234ba335aabc2f013210db8e0821a22f5e644a2e9449df199ecc23/jiter-0.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa248c9eb220197d363f688818dac2fd4b2f0cd7d843ca7105d652034823427d", size = 346055, upload-time = "2026-05-19T10:07:46.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/63/4d2749d8d54d230bad9b3a6b0d00cc28c6ff6b2fdffc26a8ccf76cc5a974/jiter-0.15.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2a77aadd57cac1682e4401a72724d2796d89a4ba129b1a5812aa94ee480826eb", size = 351406, upload-time = "2026-05-19T10:07:47.855Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b9/9965b990035d8773328e0a8c8b457a87bf2b19f6c4126d9d99296be5d16a/jiter-0.15.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2ae901f3a55bfafdde31d289590fa25e3245735a2b1e8c7cc15871710a002871", size = 389357, upload-time = "2026-05-19T10:07:49.665Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/55/9ddf903deda1413e87fed792f416b7123daee5b8efbad6a202a7421c36a5/jiter-0.15.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f0b271b462769543716f92d3a4f90527df6ef5ed05ee95ec4137f513e21e1b77", size = 517263, upload-time = "2026-05-19T10:07:51.537Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/76/a0c40ad064d3a20a4fde231e35d56e9a01ce82164278180e82d5daf85469/jiter-0.15.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2fb6a5d26af81fc0f00f9360a891e05cf755e149bba391c4d563adc54812973d", size = 548646, upload-time = "2026-05-19T10:07:53.196Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4f/eca9b954942916ba2f453891b8593ab444cd872396fe66a3936616f236f3/jiter-0.15.0-cp312-cp312-win32.whl", hash = "sha256:c2f6bb8b5216ab9e7873bc08b5d7bef2b8abbb578a3069bf1cd14a45d71d771d", size = 206427, upload-time = "2026-05-19T10:07:55.307Z" },
+    { url = "https://files.pythonhosted.org/packages/95/bf/8ead82a87495149542748e828d153fd232a512a22c83b02c4815c1a9c7d8/jiter-0.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:40b2c7e92c44a84d748d21706c68dc6ff8161d80b59c99d774721a0d2317d7c7", size = 197300, upload-time = "2026-05-19T10:07:56.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/e4/9b8a78fb2d894471bc344e37f1949bdd784bd914d031dba0ba3a40c71dd7/jiter-0.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:cc0bc345cf2df9d1c00ac443f50d543c1ccfa8b0422cb85b1ab70d681c0b255b", size = 192702, upload-time = "2026-05-19T10:07:58.307Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f4/f708c900ecee41b2025ef8413d5351e5649eb2125c506f6720cc69b06f5c/jiter-0.15.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1c11465f97e2abf45a014b83b730222f8f1c5335e802c7055a67d50de6f1f4e3", size = 307829, upload-time = "2026-05-19T10:07:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/86/59/db537c0949e83668c38481d426b9f2fd5ab758c4ee53a811dd0a510626a0/jiter-0.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d1e7b1776f0797956c509e123d0952d10d293a9492dea9f288ab9570ec01d1a5", size = 308445, upload-time = "2026-05-19T10:08:01.184Z" },
+    { url = "https://files.pythonhosted.org/packages/37/38/ea0e13b18c30ef951da0d47d39e7fa9edb82a93a62990ffbd7cea9b622d4/jiter-0.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:351a341c2105aa430b7047e30f1bf7975f6313b00165d3fc07be2edaf741f279", size = 336181, upload-time = "2026-05-19T10:08:02.688Z" },
+    { url = "https://files.pythonhosted.org/packages/58/fc/2303901b16c4ba05865588990a420c0b4156270b44379c20931544a1d962/jiter-0.15.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4ab395feec8d249ec4044e228e98a7033f043426a265df439dc3698823f0a4e4", size = 362985, upload-time = "2026-05-19T10:08:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6f/11bace093c52e7d4d26c8e606ccd7ae8c972189622469ec0d9e28161e28b/jiter-0.15.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a2a438005b6f22d0273413484d6094d7c2c5d10ec1b3a3bf128e0d1d3ba53258", size = 453292, upload-time = "2026-05-19T10:08:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/22/db/987f2f086ca4d7a6582eb4ccd513f9b26b42d9e4243a087609a3137a8fc7/jiter-0.15.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f18f85e4218d1b40f000f42a92239a7a61a902cd42c65e6c360dbd17dcb20894", size = 373501, upload-time = "2026-05-19T10:08:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/7c/89fbcabb2739b7a5b8dc959a1b6c5761f6484f5fed3486854b3c789bb1de/jiter-0.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1aa62e277fc1cbd80e6deacae6f4d983b41b3d7728e0645c5d741a6149bba45", size = 344683, upload-time = "2026-05-19T10:08:09.431Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6f/6cca7692e7dddfec6d8d76c54dc97f2af2a41df4ac0674b999df1f09a5f3/jiter-0.15.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:6550fa135c7deb8ead6af49ed7ff648532ea8334a1447fe34a36315ef79c5c29", size = 350892, upload-time = "2026-05-19T10:08:11.352Z" },
+    { url = "https://files.pythonhosted.org/packages/39/14/0338d6190cb8e6d22e677ab1d4eabd4117f67cca70c54cd04b82ff64e068/jiter-0.15.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:066f8f33f18b2419cd8213b2436fa7fbc9c499f315971cfa3ce1f9820c001b1b", size = 388723, upload-time = "2026-05-19T10:08:12.912Z" },
+    { url = "https://files.pythonhosted.org/packages/90/31/cc19f4a1bdb6afb09ce6a2f2615aa8d44d994eba0d8e6105ed1af920e736/jiter-0.15.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:75e8a04e91432dde9f1838373cf93d23726c79d3e908d319acf0e796f85592e7", size = 516648, upload-time = "2026-05-19T10:08:14.808Z" },
+    { url = "https://files.pythonhosted.org/packages/49/9f/833c541512cd091b63c10c0381973dfe11bc7a503a818c16384417e0c81e/jiter-0.15.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a97261f1fccb8e50ecd2890a96e46efdc3f57c80a197324c6777827231eca712", size = 547382, upload-time = "2026-05-19T10:08:16.927Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/11/e7b70e91f90bc4477e8eee9e8a5f7cf3cb41b4525d6394dc98a714eb8f7f/jiter-0.15.0-cp313-cp313-win32.whl", hash = "sha256:c77496cb10bd7549690fbbab3e5ec05857b83e49276f4a9423a766ddd2afcd4c", size = 205845, upload-time = "2026-05-19T10:08:18.401Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/23/5c20d9ad6f02c493e4023e5d2d09e1c1f15fe2753c9102c544aff068a88e/jiter-0.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b15741f501469009ae0ae90b7147958a664a7dede40aa7ff174a8a4645f546d0", size = 196842, upload-time = "2026-05-19T10:08:20.131Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/11/1eb400ef248e8c925fd883fbe325daf5e42cd1b0d308539dd332bd4f7ffc/jiter-0.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:5d6a60072b44c3c2b797a7ddcbcbbf2b34ea3cfd4721580fbfd2a09d9d9b84ba", size = 192212, upload-time = "2026-05-19T10:08:21.807Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/60/2fd8d7c79da8acf9b7b277c7616847773779356b92acfc9bb158452174da/jiter-0.15.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ef1fd24d9413f6209e00d3d5a453e67acfe004a25cc6c8e8484faed4311ab9e8", size = 315065, upload-time = "2026-05-19T10:08:23.218Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f4/008fb7d65e8ac2abf00811651a661e025c4ba80bbc6f378450384ddd3aed/jiter-0.15.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:144f8e72cb53dab146347b91cceac01f5481237f2b93b4a339a1ee8f8878b67c", size = 339444, upload-time = "2026-05-19T10:08:24.701Z" },
+    { url = "https://files.pythonhosted.org/packages/00/55/90b0c7b9c6896c0f2a591dd36d36b71d22e09674bfef178fa03ba3f81499/jiter-0.15.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:553fcac2ef2cb990877f9fc0833b8b629a3e6a5670b6b5fd58219b41a653ddc4", size = 347779, upload-time = "2026-05-19T10:08:26.408Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/69666cec5000fd57734c118437394516c749ae8dbeea9fb66d6fef9c4775/jiter-0.15.0-cp313-cp313t-win_amd64.whl", hash = "sha256:774f93f65031856bf14ad9f59bdcab8b8cad501e5ceabd51ba3525f76937a25b", size = 200395, upload-time = "2026-05-19T10:08:28.055Z" },
+    { url = "https://files.pythonhosted.org/packages/39/04/a6aa62cd27e8149b0d28df5561f10f6cceaf7935a9ccf3f1c5a05f9a0cd8/jiter-0.15.0-cp313-cp313t-win_arm64.whl", hash = "sha256:f1e1754960f38ec40613a07e5e372df67acb3b890fb383b6fb3de3e49ddbf3c7", size = 190516, upload-time = "2026-05-19T10:08:29.35Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/079f350ebf7859d081de30aa890f9e3be68516f754f3ba32366ffff4dcee/jiter-0.15.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:ac0d9ddea4350974be7a221fc25895f251a8fee748c889bdced2141c0fec1a49", size = 308884, upload-time = "2026-05-19T10:08:31.667Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4e/a2c30a7f69b48c03b20935d647479106fe932f6e63f75faf53937197e05d/jiter-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01a8222cf05ab1128e239421156c207949808acaaea2bdfd33130ae666786e86", size = 310028, upload-time = "2026-05-19T10:08:33.304Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/2e7cdfd3cf8ca967be38c48f5cf474d79f089efaf559a40f15984a77ae69/jiter-0.15.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:182226cbc930c9fab81bc2e41a4da672f89539906dadb05e75670ac07b94f71f", size = 337485, upload-time = "2026-05-19T10:08:35.259Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/11/15a1aa28b120b8ee5b4f1fb894c125046225f09847738bd64233d3b84883/jiter-0.15.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:71683c38c825452999b5717fcae07ea708e8c93003e808be4319c1b02e3d176e", size = 364223, upload-time = "2026-05-19T10:08:36.694Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/25/f442e8af5f3d0dcf47b39e83a0efd9ee45ea946aa6d04625dc3181eae3b6/jiter-0.15.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30f2218e6a9e5c18bc10fe6d41ac189c442c88eacf11bad9f28ef95a9bef00e6", size = 456387, upload-time = "2026-05-19T10:08:38.143Z" },
+    { url = "https://files.pythonhosted.org/packages/da/f4/37f2d2c9f64f49af7da652ed7532bb5a2372e588e6927c3fdd76f911db65/jiter-0.15.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5157de9f76eb4bc5ea74a1219366a25f945ad305641d74e04f59c54087091aa9", size = 374461, upload-time = "2026-05-19T10:08:39.869Z" },
+    { url = "https://files.pythonhosted.org/packages/60/28/edcfbbbf0cb15436f36664a8908a0df47ab9006298d4cd937dc08ea932d6/jiter-0.15.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90c5db5527c221249a876160663ab891ace358c17f7b9c93ec1478b7f0550e5c", size = 345924, upload-time = "2026-05-19T10:08:41.668Z" },
+    { url = "https://files.pythonhosted.org/packages/47/13/89fba6398dab7f202b7278c4b4aac122399d2c0183971c4a57a3b7088df5/jiter-0.15.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:3e4540b8e74e4268811ac05db226a6a128ff572e7e0ce3f1163b693cadb184cd", size = 352283, upload-time = "2026-05-19T10:08:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/da/0f6af8cef2c565a1ab44d970f268c43ccaa72707386ea6388e6fe2b6cd26/jiter-0.15.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:62ebd14e47e9aed9df4472afcb2663668ce4d74891cd54f86bf6e44029d6dc89", size = 389985, upload-time = "2026-05-19T10:08:44.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ec/b9cb7d6d29e24ee14910266157d2a279d7a8f60ee0df7fa840882976ba64/jiter-0.15.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0be6f5ad41a809f303f416d17cec92a7a725902fb9b4f3de3d19362ac0ef8554", size = 517695, upload-time = "2026-05-19T10:08:46.486Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5e/6d1bda880723aae0ad86b4b763f044362448efe31e3e819635d41cb03451/jiter-0.15.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:813dfbb17d65328bf86e5f0905dd277ba2265d3ca20556e86c0c7035b7182e5a", size = 548868, upload-time = "2026-05-19T10:08:48.026Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/72/7de501cf38dcacaf35098796f3a50e0f2e338baba18a58946c618544b809/jiter-0.15.0-cp314-cp314-win32.whl", hash = "sha256:50e51156192722a9c58db112837d3f8ef96fb3c5ecc14e95f409134b08b158ec", size = 206380, upload-time = "2026-05-19T10:08:49.738Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/a9/e19addf4b0c1bdce52c6da12351e6bc42c340c45e7c09e2158e46d293ccc/jiter-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:30ce1a5d16b5641dc935d50ef775af6a0871e3d14ab05d6fc54dff371b78e558", size = 197687, upload-time = "2026-05-19T10:08:51.088Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c9/776b1db01db25fc6c1d58d1979a37b0a9fe787e5f5b1d062d2eaacb77923/jiter-0.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:510c8b3c17a0ed9ac69850c0438dada3c9b82d9c4d589fcb62002a5a9cf3a866", size = 192571, upload-time = "2026-05-19T10:08:52.451Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f6/45bb4670bacf300fd2c7abadbfb3af376e5f1b6ae75fd9bc069891d15870/jiter-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7553333dd0930c104a5a0db8df72bf7219fe663d731383b576bb6ed6351c984d", size = 317151, upload-time = "2026-05-19T10:08:53.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/68/ed635ad5acd7b73e454283083bbb7c8205ad10e88b0d9d7d793b09fe8226/jiter-0.15.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2143ab06181d2b029eedcb6af3cebe95f11bbac62441781860f98ee9330a6a6", size = 341243, upload-time = "2026-05-19T10:08:55.383Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/db/3ff4176b817b8ea33879e71e13d8bc2b0d481a7ed3fe9e080f333d415c16/jiter-0.15.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6eac374c5c975709b69c10f09afd199df74150172156ad10c8d4fd785b7da995", size = 363629, upload-time = "2026-05-19T10:08:56.928Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/24/5f8270e0ba9c883582f96f722f8a0b58015c7ce1f8c6d4571cf394e99b6b/jiter-0.15.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b3b3b775e33d3bfaec9899edc526ae97b0da0bf9d071a46124ba419149a414f8", size = 456198, upload-time = "2026-05-19T10:08:58.618Z" },
+    { url = "https://files.pythonhosted.org/packages/45/5b/76fc02b0b5c54c3d18c60653156e2f76fde1816f9b4722db68d6ee2c897e/jiter-0.15.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3071db3346334beae1360b46da4606da57bf3528c167b3c38533afaf9f2c5", size = 373710, upload-time = "2026-05-19T10:09:00.151Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/52/4310821b0ea9277994d3e1f49fc6a4b34e4800caebacb2c0af81da59a454/jiter-0.15.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6694a173ecabc12eb60efbc0b474464ead1951ff65cd8b1e72100715c64512b", size = 349901, upload-time = "2026-05-19T10:09:01.621Z" },
+    { url = "https://files.pythonhosted.org/packages/93/fe/67648c35b3594fba8854ac64cc8a826d8bcd18324bbdb53d77697c60b6ef/jiter-0.15.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:a254e10b593624d230c365b6d616b22ca0ad65e63a16e6631c2b3466022e6ba8", size = 352438, upload-time = "2026-05-19T10:09:03.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/28/0a1879d07ad6b3e025a2750027363452ced93c2d16d1c9d4b153ffd51c91/jiter-0.15.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d8d2955167274e15d79a7a020afdd9b39c990eb80b2d89fca695d92dcfdd38ec", size = 388152, upload-time = "2026-05-19T10:09:04.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/78/46c6f6b56ba85c90021f4afd72ed42f691f8f84daacb5fe27277070e3858/jiter-0.15.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:acf4ee4d1fc55917239fe72972fb292dd773055d05eb040d36f4326e02cc2c0e", size = 517707, upload-time = "2026-05-19T10:09:06.231Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/cb/720662d4c88fcad606e826fef5424365527ba43ce4868a479aed8f8c507e/jiter-0.15.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:e7196e56f1cd69af1dbb07dff02dcfb260a50b45a82d409d92a06fedb32473b5", size = 548241, upload-time = "2026-05-19T10:09:08.093Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e3/935b8034fd143f21125c87d51404a9e0e1449186a494405721ff5d1d695e/jiter-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:7f6163c0f10b055245f814dcc59f4818da60dfe72f3e72ab89fc24b6bd5e9c52", size = 207950, upload-time = "2026-05-19T10:09:09.616Z" },
+    { url = "https://files.pythonhosted.org/packages/93/59/984fd9ece895953dad3e0880a650e766f5a2da2c5514f0eafdaaabbeb5f9/jiter-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:980c256edb05b78a111b99c4de3b1d32e31634b867fd1fc2cf726e7b7bba9854", size = 200055, upload-time = "2026-05-19T10:09:11.367Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/cf8d779feb133a27a2e3bc833bccb9e13aa332cdf820497ebf72c10ce8c3/jiter-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:66b1880df2d01e206e8339769d1c7c1753bcb653efd6289e203f6f24ebada0c0", size = 191244, upload-time = "2026-05-19T10:09:12.74Z" },
+    { url = "https://files.pythonhosted.org/packages/73/38/505941b2b092fd5bbbd60a52a880db1173f1690ae6751bed3af1c9ddcb4e/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:631f13a3d04e97d4e083993b10f4b99530e3a10d953e2eb5e196b7dc7f812ce0", size = 303769, upload-time = "2026-05-19T10:09:42.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/95/a06692b29e77473f286e1ec1f426d3ca44d7b5843be8ad21d7a5f3fcdcc0/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:b6c0ffae686c39bf3737be60793783267628783ea42545632c10b291105aee45", size = 305128, upload-time = "2026-05-19T10:09:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/23/85/7270d7ad41d6061a25b950c6bf91d638bd9aacb113200a8c8d57a055fd67/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d54fb5b31dea401a41af3f8a7d2512e9b6a6a005491e6166c7e4ffab9639a9c", size = 340459, upload-time = "2026-05-19T10:09:45.452Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8d/302cb2057b7513327b4d575cff6b1d066ee6431a5357fc3f8867cd684406/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d5d6090cdc1b7c9e780dfb04949a990adb1e301a2fc0bbcee7de4638d33f9a", size = 344469, upload-time = "2026-05-19T10:09:46.864Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/12/cfa322c5f5dd8fa21aab9a7a8e979e7a11123800f86ca8d82eb68a83d213/openai-2.38.0.tar.gz", hash = "sha256:798694c6cf74145541fda94325b6f8f72d8e1fd0262cc137c8d728177a6a4ce3", size = 772764, upload-time = "2026-05-21T21:23:42.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/bf/ccff9be562e24207716d04ef9dc931c76aff0c89a7265da43e2104d7fe06/openai-2.38.0-py3-none-any.whl", hash = "sha256:ec6661c57b2dcc47414a767e6e3335c7ed3d19c9696999283a3c82e95c756a3c", size = 1344910, upload-time = "2026-05-21T21:23:39.636Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/8a/8bce2894573e9dae6ff4d77fe34ad727d79b9e6238ad288c5638990d90f6/ruff-0.15.14.tar.gz", hash = "sha256:48e866b165be4a9bdbf310f7d3c9a07edef2fe8cd63ffeb4e00bb590506ebf9f", size = 4700910, upload-time = "2026-05-21T14:34:55.177Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/c8/74a92c6ff9fcfb4f1f947126d3ebee8389276e161ecc85de5bda7cda51bd/ruff-0.15.14-py3-none-linux_armv6l.whl", hash = "sha256:8dd2db9416e487c8d4b01fa7056bb02c4d05969d4f8d17a08c229c2f4ff3c108", size = 10739177, upload-time = "2026-05-21T14:34:37.332Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/254a35c20acc38a7223c9d2d594af12e794432464f2cdeb52af1dc4a892d/ruff-0.15.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:be4ff55af755bd71a00ab3dc6bd7ffc467bd76e0df6881e286c2e3d23e8fb43b", size = 11144969, upload-time = "2026-05-21T14:34:43.978Z" },
+    { url = "https://files.pythonhosted.org/packages/56/9e/d13e40f83b8d0a94430e6778ce1d94a43b38cf2efe63278bdd2b4c65abbf/ruff-0.15.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:48d5909d7d06276ce7dde6d32bfa4b0d4cb2651145cd8ee4b440722cbc77832f", size = 10478207, upload-time = "2026-05-21T14:34:48.378Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f1/b15a7839fa4f332f8acec78e20564f26bb2d866e3d21710b877fd0263000/ruff-0.15.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca8cbfa94c4f90984a67561978602746d4cd27103568f745fa90eee3f0d4107d", size = 10818459, upload-time = "2026-05-21T14:34:22.318Z" },
+    { url = "https://files.pythonhosted.org/packages/45/33/53d651177f84f94b400a0e27f8824eeada3dddc9d5ee8aeb048f4352a520/ruff-0.15.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9a6bbc0333f1ab053423bcbf6226477d266ca7cec7738c4c8e3f55647803f3c4", size = 10541800, upload-time = "2026-05-21T14:34:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/868f87e0bf9786ed24b5d0d0ad8676b8a94fd1912f42cddf9cfc7857818a/ruff-0.15.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a24a4f7605d7003a6674d4387651effd939dead3fddd0f36561eb77a9a2e542", size = 11342149, upload-time = "2026-05-21T14:34:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/8b/38cd5c19faffdcc05a408d2b78edccc69492ab9720eadb49ea15ef80d768/ruff-0.15.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:049b5326e53ed80978f2fc041a280603f69dd6b0c95464342a2bb4572d9d9e2f", size = 12212563, upload-time = "2026-05-21T14:34:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4d/a3c5b874a556d5731e3e657aaf04311bb76f0a5c3ec220ed43051be6b64b/ruff-0.15.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4ed42e6696c8dfa5f06728e6441993901f548eb92d73bc472cb5a38d1395fbf", size = 11493299, upload-time = "2026-05-21T14:34:41.836Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c0/56472c251d09858a53e51efbd485b09e1995d8731668b76d52e5dd6ee0f1/ruff-0.15.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:715c543cf450c4888251f91c52f1942a800541d9bddd7ac060aa4e6b77ae7cba", size = 11455931, upload-time = "2026-05-21T14:34:57.276Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/4a/e2e7b4d8dbf233d4eace59c75bc3435fa6d8bd3bae82d351d4e4300c0fd1/ruff-0.15.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ebab6013ec887d439d8b7593737a0a4ffb06d45d209d4e4bf2e92813082d3f", size = 11400794, upload-time = "2026-05-21T14:34:39.773Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c7/83c0539fe34c3e09136204d1e75d6052492364e0b3cb05e9465423f567d7/ruff-0.15.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:49072d36abdbe97a8dd7f480afe9c675699c0c495d4c84076e2c1203c4550581", size = 10804759, upload-time = "2026-05-21T14:34:31.045Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a6/18f2bfc095a2ab4a78745644e428205532ce6653a5d0fa8501572891534d/ruff-0.15.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:958522aee105068640c2c2ceae08f413ae44d922f52a1374ac13d6a96032fc93", size = 10539517, upload-time = "2026-05-21T14:34:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3a/5a8b3b69c654d4e4bf1d246ac5b49cbcdac6eaab6905925f8915f31e3b80/ruff-0.15.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f3707da619a143a2e8830e2abab8224478d69ace2d28cb6c20543ae97c36bf61", size = 11065169, upload-time = "2026-05-21T14:34:24.484Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c5/8864e4e7925b836ea354b31d57641ec03830564e281a8b6f061f8c3e0ec1/ruff-0.15.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:bb01d645694e3ec0102105d07ef2d53703970407d59c04e59d3ba0b7a1d53553", size = 11560214, upload-time = "2026-05-21T14:34:50.975Z" },
+    { url = "https://files.pythonhosted.org/packages/36/38/012bf76752e1f89ed50b77b99532d90f3a3e287bc7918e1fc0948ac866ac/ruff-0.15.14-py3-none-win32.whl", hash = "sha256:6d0c1ad2a0ab718d39b6d8fd2217981ce4d625cd96a720095f798fb47d8b13e6", size = 10805548, upload-time = "2026-05-21T14:34:33.453Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/4ea2c170f10ad760fff2a5250beb18897719dc8b52b53a24cddbb9dd3f19/ruff-0.15.14-py3-none-win_amd64.whl", hash = "sha256:802342981e056db3851a7836e5b070f8f15f67d4a685ae2a6160939d364b2902", size = 11939523, upload-time = "2026-05-21T14:34:18.077Z" },
+    { url = "https://files.pythonhosted.org/packages/62/d5/bc97ff895ec35cf3925d4bd60f3b39d822f377a446906ec9bcc87405e59b/ruff-0.15.14-py3-none-win_arm64.whl", hash = "sha256:ff47b90a9ef6a40c9e2f3b479c1fb78531adf055b94c1eba0a7ba04b31951826", size = 11208607, upload-time = "2026-05-21T14:34:26.525Z" },
+]
+
+[[package]]
+name = "skill-benchmark"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "click" },
+    { name = "openai" },
+    { name = "pydantic-settings" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "click" },
+    { name = "openai" },
+    { name = "pydantic-settings" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]


### PR DESCRIPTION
## Summary

- Added platform-agnostic workflow discipline docs (`#78`)
- Added GitHub-specific mapping (`#80`)
- Bootstrapped the `tools/skill-benchmark/` Python package foundation (`#101`)

## Test / validation

- `cd tools/skill-benchmark && uv sync`
- `uv run pytest` (passed)
- `uv run ruff check .` (passed)
- `pre-commit run --all-files` (markdownlint-cli2 hook passed)

## Notes

This is intentionally a bootstrap step. Follow-up benchmark sub-issues (`#102–#104`) will add loaders, generator orchestration, scoring, and reporting.