### PR TITLE
#102 #103 #104: Skill benchmark harness loader, scorer, runner, CLI

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -45,3 +45,4 @@ ignores:
   - "tmp/**"
   - "node_modules/**"
   - ".cursor/**"
+  - "**/.venv/**"

--- a/tools/skill-benchmark/README.md
+++ b/tools/skill-benchmark/README.md
@@ -1,6 +1,6 @@
 # skill-benchmark
 
-Skill benchmark is a small Python toolset to measure whether a skill improves agent output quality.
+Skill benchmark is a Python toolset to measure whether a skill improves agent output quality.
 
 The benchmark compares two runs of the same task:
 
@@ -9,34 +9,6 @@ The benchmark compares two runs of the same task:
 
 This makes skill quality visible and discussable with evidence instead of opinion.
 
-## Why this exists
-
-This repo has many skills. Without a benchmark flow, it is hard to answer questions like:
-
-- "Did this skill update actually help?"
-- "Which skills have the biggest impact?"
-- "Did a refactor reduce quality?"
-
-The benchmark package helps generate repeatable evidence so pull requests can include concrete results.
-
-## User stories
-
-- As a skill author, I want to compare baseline and with-skill output, so I can prove my skill adds value.
-- As a reviewer, I want to see structured benchmark evidence, so I can approve changes with more confidence.
-- As a maintainer, I want a repeatable benchmark workflow, so regressions are detected early.
-- As a contributor, I want clear extension points, so I can add new tasks, skills, and scoring logic safely.
-
-## Current scope (this bootstrap step)
-
-This first version provides the foundation:
-
-- Configuration loading (`BenchmarkConfig`)
-- OpenAI-compatible provider wrapper (`LLMProvider`)
-- CLI skeleton for future commands (`list-tasks`, `list-skills`, `run`)
-- Unit tests for config and provider behavior
-
-Follow-up issues add loaders, scoring, reports, and full orchestration.
-
 ## Quick start
 
 ### 1) Setup
@@ -44,6 +16,7 @@ Follow-up issues add loaders, scoring, reports, and full orchestration.
 ```bash
 cd tools/skill-benchmark
 uv sync
+cp .env.example .env   # optional: local Ollama defaults
 ```
 
 ### 2) Run checks
@@ -54,69 +27,88 @@ uv run ruff check .
 uv run ruff format --check .
 ```
 
-### 3) Explore the CLI skeleton
+### 3) Explore tasks and skills
 
-```bash
-uv run python -m skill_benchmark.cli --help
-```
-
-At this stage, command bodies are intentionally placeholders and will raise a "Not implemented yet" message.
-
-## Configuration
-
-Settings load from **environment variables** and from a **`.env` file** in `tools/skill-benchmark/` (gitignored). Copy `.env.example` to `.env` for local Ollama runs.
+From the repository root (or any subdirectory under it):
 
 ```bash
 cd tools/skill-benchmark
-cp .env.example .env
-# edit .env — model names, base URL, API key
+uv run skill-benchmark list-tasks
+uv run skill-benchmark list-skills
 ```
 
-See `src/skill_benchmark/README.md` for the end-to-end benchmark workflow and example task.
+### 4) Dry-run (no LLM calls)
 
-### Core LLM settings
-
-- `OPENAI_API_KEY`: API key for OpenAI-compatible endpoints
-- `BENCHMARK_LLM_BASE_URL`: base URL for generation model endpoint
-- `BENCHMARK_LLM_MODEL`: model name for generation calls
-- `BENCHMARK_SCORER_BASE_URL`: base URL for scorer model endpoint
-- `BENCHMARK_SCORER_MODEL`: model name for scorer calls
-
-### Paths
-
-- `BENCHMARK_TMP_DIR`: scratch output location (default: `tmp/skills/benchmark`)
-- `BENCHMARK_DOCS_DIR`: report output location (default: `docs/skills/benchmark`)
-
-### Example (PowerShell)
-
-```powershell
-$env:OPENAI_API_KEY="your-key"
-$env:BENCHMARK_LLM_BASE_URL="http://localhost:11434/v1"
-$env:BENCHMARK_LLM_MODEL="qwen2.5-coder:14b"
+```bash
+uv run skill-benchmark run issue-workflow issue-creation --dry-run
 ```
 
-## How to extend or change
+### 5) Full benchmark run
 
-### Add a new benchmark task
+Requires `OPENAI_API_KEY` (or a compatible local endpoint such as Ollama):
 
-1. Add a task markdown file under `docs/skills/benchmark/tasks/`
-2. Keep task prompt and expected coverage explicit
-3. Add loader tests once loader implementation is added
+```bash
+uv run skill-benchmark run issue-workflow issue-creation \
+  --base-url http://localhost:11434/v1 \
+  --model qwen2.5-coder:14b \
+  --scorer-model qwen2.5-coder:14b
+```
 
-### Add a new provider behavior
+**Outputs:**
 
-1. Extend `LLMProvider` in `src/skill_benchmark/provider.py`
-2. Keep API surface backward compatible (`complete(...) -> LLMResponse`)
-3. Add tests in `tests/test_provider.py`
+| Artefact | Location |
+|----------|----------|
+| Baseline output | `tmp/skills/benchmark/<skill>/output-baseline.md` |
+| With-skill output | `tmp/skills/benchmark/<skill>/output-with-skill.md` |
+| Report | `docs/skills/benchmark/<skill>/report.md` |
 
-### Add new CLI command behavior
+## Configuration
 
-1. Implement command flow in `src/skill_benchmark/cli.py`
-2. Keep command help text user-focused
-3. Add command tests and README usage examples
+Settings load from environment variables and from `.env` in `tools/skill-benchmark/`.
+
+| Variable | Purpose |
+|----------|---------|
+| `OPENAI_API_KEY` | API key for OpenAI-compatible endpoints |
+| `BENCHMARK_LLM_BASE_URL` | Generation model base URL |
+| `BENCHMARK_LLM_MODEL` | Generation model name |
+| `BENCHMARK_SCORER_BASE_URL` | Scorer model base URL |
+| `BENCHMARK_SCORER_MODEL` | Scorer model name |
+| `BENCHMARK_TMP_DIR` | Scratch output (default: `tmp/skills/benchmark`) |
+| `BENCHMARK_DOCS_DIR` | Report output (default: `docs/skills/benchmark`) |
+
+Paths are resolved relative to the repository root (directory containing `skills/SKILL_TREE.md`).
+
+## CLI reference
+
+```bash
+uv run skill-benchmark list-tasks
+uv run skill-benchmark list-skills
+uv run skill-benchmark run <skill-name> <task-name> [--dry-run] [--base-url URL] [--model NAME] [--scorer-model NAME]
+```
+
+## Architecture
+
+| Module | Role |
+|--------|------|
+| `loader.py` | Load tasks from `docs/skills/benchmark/tasks/` and skills from `skills/` |
+| `agents/generator.py` | Baseline and with-skill LLM generation (isolated contexts) |
+| `agents/scorer.py` | Four-dimension JSON scoring via separate scorer model |
+| `report.py` | Markdown report matching `docs/skills/benchmark/*/report.md` format |
+| `runner.py` | End-to-end orchestration and artefact persistence |
+
+## Verdict thresholds
+
+| Delta (skilled − baseline) | Verdict |
+|----------------------------|---------|
+| ≥ +4 | significant improvement |
+| +1 to +3 | marginal |
+| ≤ 0 | no improvement |
 
 ## Design notes
 
-- This package uses OpenAI-compatible APIs, which allows local and cloud providers behind one interface.
-- Provider injection in tests avoids real API calls and keeps unit tests fast.
-- Configuration uses environment variables to keep secrets out of code and out of git history.
+- OpenAI-compatible APIs allow local (Ollama) and cloud providers behind one interface.
+- Baseline and with-skill runs use separate message lists (no context contamination).
+- The scorer evaluates each output independently (no side-by-side bias).
+- Provider injection in tests avoids real API calls.
+
+See also [validation/skill-benchmark](../../skills/validation/skill-benchmark/SKILL.md) for the manual benchmark rubric.

--- a/tools/skill-benchmark/pyproject.toml
+++ b/tools/skill-benchmark/pyproject.toml
@@ -20,6 +20,9 @@ dependencies = [
 [tool.setuptools]
 package-dir = {"" = "src"}
 
+[project.scripts]
+skill-benchmark = "skill_benchmark.cli:cli"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/tools/skill-benchmark/src/skill_benchmark/agents/__init__.py
+++ b/tools/skill-benchmark/src/skill_benchmark/agents/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmark agent implementations."""

--- a/tools/skill-benchmark/src/skill_benchmark/agents/__init__.py
+++ b/tools/skill-benchmark/src/skill_benchmark/agents/__init__.py
@@ -1,1 +1,39 @@
-"""Benchmark agent implementations."""
+"""LLM agents for the skill benchmark harness.
+
+This package holds the two model-backed steps in a benchmark run:
+
+1. **Generator** — produces task output with and without skill context.
+2. **Scorer** — rates each output on coverage, specificity, correctness, and
+   completeness.
+
+Both agents use :class:`~skill_benchmark.provider.LLMProvider` and are wired
+by :class:`~skill_benchmark.runner.BenchmarkRunner`. See
+``skills/validation/skill-benchmark/SKILL.md`` for the manual benchmark
+workflow this harness automates.
+
+Exports
+-------
+GeneratorAgent
+    Baseline and with-skill generation for one task prompt.
+ScorerAgent
+    Independent rubric scoring for one generated output.
+
+Example
+-------
+Inject agents in tests or call via the runner::
+
+    from skill_benchmark.agents import GeneratorAgent, ScorerAgent
+    from skill_benchmark.config import BenchmarkConfig
+    from skill_benchmark.provider import LLMProvider
+
+    config = BenchmarkConfig()
+    generator = GeneratorAgent(LLMProvider(config))
+    scorer = ScorerAgent(config)
+
+    # Typical use is through BenchmarkRunner.run(skill_name, task_name).
+"""
+
+from .generator import GeneratorAgent
+from .scorer import ScorerAgent
+
+__all__ = ["GeneratorAgent", "ScorerAgent"]

--- a/tools/skill-benchmark/src/skill_benchmark/agents/generator.py
+++ b/tools/skill-benchmark/src/skill_benchmark/agents/generator.py
@@ -1,4 +1,13 @@
-"""Generator agent for baseline and with-skill benchmark runs."""
+"""Generate benchmark outputs with and without skill context.
+
+The generator runs the same task prompt twice: once as a baseline (prompt only)
+and once with the skill markdown injected into the system message. Each call
+returns a :class:`~skill_benchmark.models.GenerationResult` with markdown
+output and token usage for the report.
+
+Deliverable: two comparable outputs per task so the scorer can measure skill
+impact. Used by :class:`~skill_benchmark.runner.BenchmarkRunner`.
+"""
 
 from __future__ import annotations
 

--- a/tools/skill-benchmark/src/skill_benchmark/agents/generator.py
+++ b/tools/skill-benchmark/src/skill_benchmark/agents/generator.py
@@ -1,0 +1,67 @@
+"""Generator agent for baseline and with-skill benchmark runs."""
+
+from __future__ import annotations
+
+from skill_benchmark.models import GenerationResult, SkillContent, TaskPrompt
+from skill_benchmark.provider import LLMProvider
+
+_BASELINE_SYSTEM = (
+    "You are a software engineer. Create a GitHub issue based on the following task. "
+    "Return only the issue body in markdown."
+)
+
+_WITH_SKILL_SYSTEM = (
+    "You are a software engineer. Create a GitHub issue based on the following task. "
+    "Use the skill reference material below to improve structure and quality. "
+    "Return only the issue body in markdown.\n\n"
+    "--- Skill reference ---\n{skill_content}"
+)
+
+
+class GeneratorAgent:
+    """Generate benchmark outputs with and without skill context."""
+
+    def __init__(self, provider: LLMProvider) -> None:
+        """Create a generator backed by an LLM provider.
+
+        Args:
+            provider (LLMProvider): OpenAI-compatible provider for generation calls.
+        """
+
+        self._provider = provider
+
+    async def generate(
+        self,
+        task: TaskPrompt,
+        skill: SkillContent | None = None,
+    ) -> GenerationResult:
+        """Generate output for one task, optionally with skill context.
+
+        Baseline and with-skill runs use separate message lists so context does not
+        leak between them.
+
+        Args:
+            task (TaskPrompt): Benchmark task prompt.
+            skill (SkillContent | None): Skill markdown to inject into the system
+                prompt. When ``None``, run baseline (prompt only).
+
+        Returns:
+            GenerationResult: Generated markdown and token usage metadata.
+        """
+
+        if skill is None:
+            system_prompt = _BASELINE_SYSTEM
+        else:
+            system_prompt = _WITH_SKILL_SYSTEM.format(skill_content=skill.content)
+
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": task.prompt},
+        ]
+        response = await self._provider.complete(messages=messages, temperature=0.0)
+        return GenerationResult(
+            output=response.content,
+            model=response.model,
+            input_tokens=response.input_tokens,
+            output_tokens=response.output_tokens,
+        )

--- a/tools/skill-benchmark/src/skill_benchmark/agents/scorer.py
+++ b/tools/skill-benchmark/src/skill_benchmark/agents/scorer.py
@@ -1,0 +1,139 @@
+"""Scorer agent for evaluating benchmark outputs."""
+
+from __future__ import annotations
+
+import json
+import re
+
+from skill_benchmark.config import BenchmarkConfig
+from skill_benchmark.models import DimensionScore, ScoringResult, TaskPrompt
+from skill_benchmark.provider import LLMProvider
+
+_SCORER_SYSTEM = """You evaluate software-engineering task output on four dimensions.
+Score each dimension from 1 to 5 (integers only).
+
+Dimensions:
+- coverage: Did the output address all required sub-tasks?
+- specificity: Are commands, formats, and values concrete (not vague)?
+- correctness: Is the output factually and technically correct?
+- completeness: Could an engineer act on this output without further clarification?
+
+Return ONLY valid JSON with this shape:
+{
+  "coverage": {"score": 1, "rationale": "..."},
+  "specificity": {"score": 1, "rationale": "..."},
+  "correctness": {"score": 1, "rationale": "..."},
+  "completeness": {"score": 1, "rationale": "..."}
+}
+"""
+
+
+class ScorerAgent:
+    """Score one generated output independently."""
+
+    def __init__(self, config: BenchmarkConfig, client=None) -> None:
+        """Create a scorer using the scorer model configuration.
+
+        Args:
+            config (BenchmarkConfig): Benchmark settings including scorer URL/model.
+            client: Optional injected client for tests.
+        """
+
+        scorer_config = config.model_copy(
+            update={
+                "llm_base_url": config.scorer_base_url,
+                "llm_model": config.scorer_model,
+            }
+        )
+        self._provider = LLMProvider(scorer_config, client=client)
+
+    async def score(self, task: TaskPrompt, output: str) -> ScoringResult:
+        """Score one output against the task rubric.
+
+        The scorer sees only one output at a time to avoid comparison bias.
+
+        Args:
+            task (TaskPrompt): Original benchmark task.
+            output (str): Generated markdown to evaluate.
+
+        Returns:
+            ScoringResult: Structured dimension scores.
+
+        Raises:
+            ValueError: If the model response cannot be parsed as valid JSON scores.
+        """
+
+        user_prompt = (
+            f"Task prompt:\n{task.prompt}\n\n"
+            f"Expected coverage:\n{task.expected_coverage or '(not specified)'}\n\n"
+            f"Output to score:\n{output}"
+        )
+        messages = [
+            {"role": "system", "content": _SCORER_SYSTEM},
+            {"role": "user", "content": user_prompt},
+        ]
+
+        last_error: Exception | None = None
+        for attempt in range(2):
+            response = await self._provider.complete(messages=messages, temperature=0.0)
+            try:
+                return _parse_scoring_result(response.content)
+            except ValueError as exc:
+                last_error = exc
+                if attempt == 0:
+                    messages.append({"role": "assistant", "content": response.content})
+                    messages.append(
+                        {
+                            "role": "user",
+                            "content": "Your previous response was not valid JSON. "
+                            "Return ONLY the JSON object with integer scores 1-5.",
+                        }
+                    )
+        raise ValueError("Scorer returned invalid JSON after retry.") from last_error
+
+
+def _parse_scoring_result(raw: str) -> ScoringResult:
+    """Parse scorer JSON into a ScoringResult."""
+
+    payload = _extract_json_object(raw)
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Scorer response is not valid JSON.") from exc
+
+    return ScoringResult(
+        coverage=_parse_dimension(data, "coverage"),
+        specificity=_parse_dimension(data, "specificity"),
+        correctness=_parse_dimension(data, "correctness"),
+        completeness=_parse_dimension(data, "completeness"),
+    )
+
+
+def _extract_json_object(raw: str) -> str:
+    """Return the first JSON object found in a model response."""
+
+    fenced = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", raw, flags=re.DOTALL)
+    if fenced:
+        return fenced.group(1)
+    start = raw.find("{")
+    end = raw.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        raise ValueError("No JSON object found in scorer response.")
+    return raw[start : end + 1]
+
+
+def _parse_dimension(data: dict, key: str) -> DimensionScore:
+    """Parse one dimension entry from scorer JSON."""
+
+    entry = data.get(key)
+    if not isinstance(entry, dict):
+        raise ValueError(f"Missing dimension: {key}")
+
+    score = entry.get("score")
+    rationale = entry.get("rationale", "")
+    if not isinstance(score, int) or score < 1 or score > 5:
+        raise ValueError(f"Invalid score for {key}: {score!r}")
+    if not isinstance(rationale, str):
+        raise ValueError(f"Invalid rationale for {key}.")
+
+    return DimensionScore(score=score, rationale=rationale.strip())

--- a/tools/skill-benchmark/src/skill_benchmark/agents/scorer.py
+++ b/tools/skill-benchmark/src/skill_benchmark/agents/scorer.py
@@ -1,4 +1,13 @@
-"""Scorer agent for evaluating benchmark outputs."""
+"""Score one generated output against the benchmark rubric.
+
+The scorer evaluates a single output in isolation (no side-by-side comparison)
+on four dimensions: coverage, specificity, correctness, and completeness.
+It returns a structured :class:`~skill_benchmark.models.ScoringResult` parsed
+from model JSON, with one retry when the response is invalid.
+
+Deliverable: repeatable 1–5 dimension scores and rationales for baseline and
+with-skill runs. Used by :class:`~skill_benchmark.runner.BenchmarkRunner`.
+"""
 
 from __future__ import annotations
 

--- a/tools/skill-benchmark/src/skill_benchmark/cli.py
+++ b/tools/skill-benchmark/src/skill_benchmark/cli.py
@@ -1,4 +1,10 @@
-"""CLI for the skill benchmark harness."""
+"""Command-line interface for the skill benchmark harness.
+
+Commands: ``list-tasks``, ``list-skills``, and ``run`` (with ``--dry-run``,
+``--base-url``, ``--model``, ``--scorer-model`` overrides).
+
+Deliverable: operator entry point installed as the ``skill-benchmark`` console script.
+"""
 
 from __future__ import annotations
 

--- a/tools/skill-benchmark/src/skill_benchmark/cli.py
+++ b/tools/skill-benchmark/src/skill_benchmark/cli.py
@@ -1,113 +1,120 @@
-"""CLI for the skill benchmark harness.
+"""CLI for the skill benchmark harness."""
 
-Purpose:
-    Give maintainers simple commands to list tasks/skills and run benchmarks.
+from __future__ import annotations
 
-What it helps with:
-    - Discover which benchmark tasks and skills exist
-    - Run baseline vs with-skill comparisons (once #104 lands)
-    - Produce evidence files for pull requests
-
-This module is a thin wrapper around Click. You do not need to know Click internals
-to use it: run `uv run python -m skill_benchmark.cli --help`.
-"""
+import asyncio
 
 import click
+
+from .config import BenchmarkConfig
+from .loader import SkillLoader, TaskLoader
+from .paths import find_repo_root
+from .runner import BenchmarkRunner
+
+
+def _build_config(
+    base_url: str | None,
+    model: str | None,
+    scorer_model: str | None,
+) -> BenchmarkConfig:
+    """Build config with optional CLI overrides."""
+
+    updates: dict[str, object] = {"_env_file": None}
+    if base_url:
+        updates["llm_base_url"] = base_url
+        updates["scorer_base_url"] = base_url
+    if model:
+        updates["llm_model"] = model
+    if scorer_model:
+        updates["scorer_model"] = scorer_model
+    return BenchmarkConfig(**updates)
 
 
 @click.group()
 def cli() -> None:
-    """Skill benchmark harness — compare agent output with and without skills.
-
-    Goal:
-        Measure whether a skill improves task output quality using repeatable runs.
-
-    What you can do (today vs planned):
-        - Today (#101): show help; sub-commands are placeholders
-        - #102: list tasks and skills from the repo
-        - #104: run full benchmark and write reports
-
-    Run from: tools/skill-benchmark/
-    """
+    """Skill benchmark harness — compare agent output with and without skills."""
 
 
 @cli.command("list-tasks")
 def list_tasks() -> None:
-    """List benchmark task prompts available under docs/skills/benchmark/tasks/.
+    """List benchmark task prompts available under docs/skills/benchmark/tasks/."""
 
-    Purpose:
-        Show which tasks you can run against a skill.
-
-    Planned behavior (#102):
-        Print one task name per line (e.g. issue-creation, rbac-spec).
-
-    Examples (expected once implemented):
-
-        $ uv run python -m skill_benchmark.cli list-tasks
-        issue-creation
-        rbac-spec
-
-    Exit code: 0 on success.
-    """
-
-    raise click.ClickException("Not implemented yet.")
+    repo_root = find_repo_root()
+    for name in TaskLoader(repo_root).list_tasks():
+        click.echo(name)
 
 
 @cli.command("list-skills")
 def list_skills() -> None:
-    """List skills that can be benchmarked from the skills/ tree.
+    """List top-level skills discoverable under skills/."""
 
-    Purpose:
-        Show skill directory names you can pass to `run`.
-
-    Planned behavior (#102):
-        Discover directories containing SKILL.md under skills/.
-
-    Examples (expected once implemented):
-
-        $ uv run python -m skill_benchmark.cli list-skills
-        issue-workflow
-        deployment-release
-
-    Exit code: 0 on success.
-    """
-
-    raise click.ClickException("Not implemented yet.")
+    repo_root = find_repo_root()
+    for name in SkillLoader(repo_root).list_skills():
+        click.echo(name)
 
 
 @cli.command("run")
 @click.argument("skill_name", required=True)
 @click.argument("task_name", required=True)
-def run_benchmark(skill_name: str, task_name: str) -> None:
-    """Run one full benchmark: baseline and with-skill, then score and report.
+@click.option("--base-url", default=None, help="Override LLM and scorer base URL.")
+@click.option("--model", default=None, help="Override generation model name.")
+@click.option("--scorer-model", default=None, help="Override scorer model name.")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Validate task/skill paths and config without calling the LLM.",
+)
+def run_benchmark(
+    skill_name: str,
+    task_name: str,
+    base_url: str | None,
+    model: str | None,
+    scorer_model: str | None,
+    dry_run: bool,
+) -> None:
+    """Run one full benchmark: baseline and with-skill, then score and report."""
 
-    Purpose:
-        Produce comparable evidence for a single skill on a single task.
+    repo_root = find_repo_root()
+    task_loader = TaskLoader(repo_root)
+    skill_loader = SkillLoader(repo_root)
 
-    Planned behavior (#104):
-        1. Load task prompt and skill SKILL.md
-        2. Call LLM twice (isolated contexts)
-        3. Score each output
-        4. Write tmp outputs and docs/skills/benchmark/<skill>/report.md
+    if task_name not in task_loader.list_tasks():
+        raise click.ClickException(f"Unknown task: {task_name}")
+    if skill_name not in skill_loader.list_skills():
+        raise click.ClickException(f"Unknown skill: {skill_name}")
 
-    Examples (expected once implemented):
+    config = _build_config(base_url, model, scorer_model)
 
-        $ uv run python -m skill_benchmark.cli run issue-workflow issue-creation
+    if dry_run:
+        tmp_dir = repo_root / config.tmp_dir if not config.tmp_dir.is_absolute() else config.tmp_dir
+        docs_dir = (
+            repo_root / config.docs_dir if not config.docs_dir.is_absolute() else config.docs_dir
+        )
+        click.echo(f"Repo root: {repo_root}")
+        click.echo(f"Task: {task_name}")
+        click.echo(f"Skill: {skill_name}")
+        click.echo(f"LLM: {config.llm_model} @ {config.llm_base_url}")
+        click.echo(f"Scorer: {config.scorer_model} @ {config.scorer_base_url}")
+        click.echo(f"Tmp dir: {tmp_dir.resolve()}")
+        click.echo(f"Docs dir: {docs_dir.resolve()}")
+        click.echo("Dry run OK — no LLM calls made.")
+        return
 
-    Expected console output (summary):
-        - Paths to output-baseline.md and output-with-skill.md
-        - Path to report.md
-        - Verdict: significant improvement | marginal | no improvement
+    if not config.api_key:
+        raise click.ClickException(
+            "OPENAI_API_KEY is required for benchmark runs (or use --dry-run)."
+        )
 
-    Expected artefacts:
-        - tmp/skills/benchmark/issue-workflow/output-baseline.md
-        - tmp/skills/benchmark/issue-workflow/output-with-skill.md
-        - docs/skills/benchmark/issue-workflow/report.md
+    runner = BenchmarkRunner(config, repo_root=repo_root)
 
-    Exit code: 0 on success; non-zero if LLM or scoring fails.
-    """
+    comparison = asyncio.run(runner.run(skill_name, task_name))
+    report_path = runner.resolve_docs_dir() / skill_name / "report.md"
+    tmp_dir = runner.resolve_tmp_dir() / skill_name
 
-    raise click.ClickException(f"Not implemented yet (skill={skill_name}, task={task_name}).")
+    click.echo(f"Baseline output: {tmp_dir / 'output-baseline.md'}")
+    click.echo(f"With-skill output: {tmp_dir / 'output-with-skill.md'}")
+    click.echo(f"Report: {report_path}")
+    click.echo(f"Verdict: {comparison.verdict} (delta {comparison.delta:+d})")
 
 
 if __name__ == "__main__":

--- a/tools/skill-benchmark/src/skill_benchmark/config.py
+++ b/tools/skill-benchmark/src/skill_benchmark/config.py
@@ -24,6 +24,7 @@ class BenchmarkConfig(BaseSettings):
         extra="ignore",
         env_file=".env",
         env_file_encoding="utf-8",
+        populate_by_name=True,
     )
 
     api_key: str = Field(default="", validation_alias="OPENAI_API_KEY")

--- a/tools/skill-benchmark/src/skill_benchmark/loader.py
+++ b/tools/skill-benchmark/src/skill_benchmark/loader.py
@@ -1,4 +1,11 @@
-"""Load benchmark tasks and skill content from the repository."""
+"""Load benchmark tasks and skill markdown from the repository.
+
+``TaskLoader`` reads versioned prompts from ``docs/skills/benchmark/tasks/``.
+``SkillLoader`` reads ``SKILL.md`` from ``skills/<name>/``.
+
+Deliverable: parsed :class:`~skill_benchmark.models.TaskPrompt` and
+:class:`~skill_benchmark.models.SkillContent` objects for agents and the runner.
+"""
 
 from __future__ import annotations
 

--- a/tools/skill-benchmark/src/skill_benchmark/loader.py
+++ b/tools/skill-benchmark/src/skill_benchmark/loader.py
@@ -1,0 +1,130 @@
+"""Load benchmark tasks and skill content from the repository."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .models import SkillContent, TaskPrompt
+from .paths import find_repo_root
+
+
+class TaskLoader:
+    """Discover and parse benchmark task markdown files."""
+
+    def __init__(self, repo_root: Path | None = None) -> None:
+        """Create a task loader rooted at the repository.
+
+        Args:
+            repo_root (Path | None): Repository root. When omitted, it is
+                discovered automatically.
+        """
+
+        self._repo_root = repo_root or find_repo_root()
+        self._tasks_dir = self._repo_root / "docs" / "skills" / "benchmark" / "tasks"
+
+    def list_tasks(self) -> list[str]:
+        """Return sorted task names (filename stems without .md)."""
+
+        if not self._tasks_dir.is_dir():
+            return []
+        return sorted(path.stem for path in self._tasks_dir.glob("*.md"))
+
+    def load(self, task_name: str) -> TaskPrompt:
+        """Load one task by name.
+
+        Args:
+            task_name (str): Task file stem (for example `issue-creation`).
+
+        Returns:
+            TaskPrompt: Parsed task prompt and expected coverage.
+
+        Raises:
+            FileNotFoundError: If the task file does not exist.
+            ValueError: If required sections are missing.
+        """
+
+        task_path = self._tasks_dir / f"{task_name}.md"
+        if not task_path.is_file():
+            raise FileNotFoundError(f"Task not found: {task_name} ({task_path})")
+
+        text = task_path.read_text(encoding="utf-8")
+        prompt = _extract_section(text, "Task prompt")
+        expected_coverage = _extract_section(text, "Expected coverage")
+        skill_under_test = _extract_metadata_field(text, "Skill under test")
+
+        if not prompt:
+            raise ValueError(f"Task {task_name} is missing a '## Task prompt' section.")
+
+        return TaskPrompt(
+            name=task_name,
+            prompt=prompt.strip(),
+            expected_coverage=expected_coverage.strip(),
+            skill_under_test=skill_under_test,
+        )
+
+
+class SkillLoader:
+    """Discover and load SKILL.md files from the skills tree."""
+
+    def __init__(self, repo_root: Path | None = None) -> None:
+        """Create a skill loader rooted at the repository.
+
+        Args:
+            repo_root (Path | None): Repository root. When omitted, it is
+                discovered automatically.
+        """
+
+        self._repo_root = repo_root or find_repo_root()
+        self._skills_dir = self._repo_root / "skills"
+
+    def list_skills(self) -> list[str]:
+        """Return sorted skill directory names that contain SKILL.md."""
+
+        if not self._skills_dir.is_dir():
+            return []
+
+        names: set[str] = set()
+        for skill_md in self._skills_dir.rglob("SKILL.md"):
+            relative = skill_md.parent.relative_to(self._skills_dir)
+            if relative.parts:
+                names.add(relative.parts[0])
+        return sorted(names)
+
+    def load(self, skill_name: str) -> SkillContent:
+        """Load the top-level skill markdown for a skill directory name.
+
+        Args:
+            skill_name (str): First path segment under `skills/` (for example
+                `issue-workflow`).
+
+        Returns:
+            SkillContent: Skill name and markdown body.
+
+        Raises:
+            FileNotFoundError: If `skills/<skill_name>/SKILL.md` does not exist.
+        """
+
+        skill_path = self._skills_dir / skill_name / "SKILL.md"
+        if not skill_path.is_file():
+            raise FileNotFoundError(f"Skill not found: {skill_name} ({skill_path})")
+
+        return SkillContent(name=skill_name, content=skill_path.read_text(encoding="utf-8"))
+
+
+def _extract_section(text: str, heading: str) -> str:
+    """Return body text for a level-2 markdown heading."""
+
+    pattern = rf"^## {re.escape(heading)}\s*\n(.*?)(?=^## |\Z)"
+    match = re.search(pattern, text, flags=re.MULTILINE | re.DOTALL)
+    return match.group(1).strip() if match else ""
+
+
+def _extract_metadata_field(text: str, field_name: str) -> str | None:
+    """Return a bold metadata field value from task markdown."""
+
+    pattern = rf"\*\*{re.escape(field_name)}:\*\*\s*(.+)"
+    match = re.search(pattern, text)
+    if not match:
+        return None
+    return match.group(1).strip()

--- a/tools/skill-benchmark/src/skill_benchmark/models.py
+++ b/tools/skill-benchmark/src/skill_benchmark/models.py
@@ -1,4 +1,10 @@
-"""Data models for skill benchmark runs."""
+"""Data models shared across loaders, agents, runner, and report.
+
+Includes task and skill inputs, generation and scoring results, and the
+aggregate :class:`BenchmarkComparison` used for report generation.
+
+Deliverable: typed dataclasses passed between benchmark pipeline stages.
+"""
 
 from dataclasses import dataclass
 

--- a/tools/skill-benchmark/src/skill_benchmark/models.py
+++ b/tools/skill-benchmark/src/skill_benchmark/models.py
@@ -1,0 +1,88 @@
+"""Data models for skill benchmark runs."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TaskPrompt:
+    """A benchmark task loaded from docs/skills/benchmark/tasks/."""
+
+    name: str
+    prompt: str
+    expected_coverage: str
+    skill_under_test: str | None = None
+
+
+@dataclass(frozen=True)
+class SkillContent:
+    """Skill markdown content loaded from skills/<name>/SKILL.md."""
+
+    name: str
+    content: str
+
+
+@dataclass(frozen=True)
+class GenerationResult:
+    """Output from a single LLM generation call."""
+
+    output: str
+    model: str
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+
+
+@dataclass(frozen=True)
+class DimensionScore:
+    """Score for one rubric dimension with rationale."""
+
+    score: int
+    rationale: str
+
+
+@dataclass(frozen=True)
+class ScoringResult:
+    """Four-dimension scoring result (total out of 20)."""
+
+    coverage: DimensionScore
+    specificity: DimensionScore
+    correctness: DimensionScore
+    completeness: DimensionScore
+
+    @property
+    def total(self) -> int:
+        """Return the sum of all dimension scores."""
+
+        return (
+            self.coverage.score
+            + self.specificity.score
+            + self.correctness.score
+            + self.completeness.score
+        )
+
+
+@dataclass(frozen=True)
+class BenchmarkComparison:
+    """Baseline vs with-skill comparison for one task."""
+
+    task: TaskPrompt
+    skill_name: str
+    baseline_output: str
+    skilled_output: str
+    baseline_score: ScoringResult
+    skilled_score: ScoringResult
+
+    @property
+    def delta(self) -> int:
+        """Return skilled total minus baseline total."""
+
+        return self.skilled_score.total - self.baseline_score.total
+
+    @property
+    def verdict(self) -> str:
+        """Return a human-readable verdict label."""
+
+        if self.delta >= 4:
+            return "significant improvement"
+        if self.delta >= 1:
+            return "marginal"
+        return "no improvement"

--- a/tools/skill-benchmark/src/skill_benchmark/paths.py
+++ b/tools/skill-benchmark/src/skill_benchmark/paths.py
@@ -1,0 +1,26 @@
+"""Resolve repository paths for benchmark loaders and output writers."""
+
+from pathlib import Path
+
+
+def find_repo_root(start: Path | None = None) -> Path:
+    """Locate the repository root by walking up for `skills/SKILL_TREE.md`.
+
+    Args:
+        start (Path | None): Directory to start from. Defaults to the current
+            working directory.
+
+    Returns:
+        Path: Absolute path to the repository root.
+
+    Raises:
+        FileNotFoundError: If no repository root marker is found.
+    """
+
+    current = (start or Path.cwd()).resolve()
+    for candidate in [current, *current.parents]:
+        if (candidate / "skills" / "SKILL_TREE.md").is_file():
+            return candidate
+    raise FileNotFoundError(
+        "Could not find repository root (expected skills/SKILL_TREE.md in a parent directory)."
+    )

--- a/tools/skill-benchmark/src/skill_benchmark/paths.py
+++ b/tools/skill-benchmark/src/skill_benchmark/paths.py
@@ -1,4 +1,10 @@
-"""Resolve repository paths for benchmark loaders and output writers."""
+"""Resolve repository root for benchmark loaders and output paths.
+
+Walks up from the current directory until ``skills/SKILL_TREE.md`` is found
+so tasks, skills, and reports resolve correctly regardless of cwd.
+
+Deliverable: stable :func:`find_repo_root` for CLI and runner path resolution.
+"""
 
 from pathlib import Path
 

--- a/tools/skill-benchmark/src/skill_benchmark/report.py
+++ b/tools/skill-benchmark/src/skill_benchmark/report.py
@@ -1,4 +1,11 @@
-"""Markdown report generation for benchmark comparisons."""
+"""Render and persist markdown benchmark comparison reports.
+
+Turns a :class:`~skill_benchmark.models.BenchmarkComparison` into a human-readable
+report with dimension scores, deltas, and a verdict. Saves to
+``docs/skills/benchmark/<skill-name>/report.md``.
+
+Deliverable: committed evidence for skill PRs and regression checks.
+"""
 
 from __future__ import annotations
 

--- a/tools/skill-benchmark/src/skill_benchmark/report.py
+++ b/tools/skill-benchmark/src/skill_benchmark/report.py
@@ -1,0 +1,127 @@
+"""Markdown report generation for benchmark comparisons."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .models import BenchmarkComparison, ScoringResult
+
+
+class ReportGenerator:
+    """Render and persist benchmark comparison reports."""
+
+    def generate(self, comparison: BenchmarkComparison) -> str:
+        """Build a markdown report for one benchmark run.
+
+        Args:
+            comparison (BenchmarkComparison): Baseline vs with-skill comparison.
+
+        Returns:
+            str: Markdown report body.
+        """
+
+        task = comparison.task
+        baseline = comparison.baseline_score
+        skilled = comparison.skilled_score
+
+        lines = [
+            f"# Skill Benchmark — {comparison.skill_name}",
+            "",
+            f"**Task:** {task.name}",
+            "",
+            "## Task prompt",
+            "",
+            task.prompt,
+            "",
+            "## Scoring (1–5 per dimension)",
+            "",
+            "| Dimension | Without Skill | With Skill | Delta |",
+            "|-----------|---------------|------------|-------|",
+            _score_row("Coverage", baseline.coverage.score, skilled.coverage.score),
+            _score_row("Specificity", baseline.specificity.score, skilled.specificity.score),
+            _score_row("Correctness", baseline.correctness.score, skilled.correctness.score),
+            _score_row("Completeness", baseline.completeness.score, skilled.completeness.score),
+            (
+                f"| **Total** | **{baseline.total}/20** | **{skilled.total}/20** | "
+                f"**{comparison.delta:+d}** |"
+            ),
+            "",
+            "## Verdict",
+            "",
+            f"**{comparison.verdict.title()}** — delta {comparison.delta:+d} "
+            f"({baseline.total}/20 → {skilled.total}/20).",
+            "",
+            "## Key observation",
+            "",
+            _key_observation(comparison),
+            "",
+            "## Scoring rationale",
+            "",
+            "### Without skill",
+            "",
+            _rationale_block(baseline),
+            "",
+            "### With skill",
+            "",
+            _rationale_block(skilled),
+        ]
+        return "\n".join(lines)
+
+    def save(self, report: str, skill_name: str, docs_dir: Path) -> Path:
+        """Write a report to docs/skills/benchmark/<skill>/report.md.
+
+        Args:
+            report (str): Markdown report body.
+            skill_name (str): Skill directory name.
+            docs_dir (Path): Base docs output directory (repo-relative resolved).
+
+        Returns:
+            Path: Path to the written report file.
+        """
+
+        output_dir = docs_dir / skill_name
+        output_dir.mkdir(parents=True, exist_ok=True)
+        report_path = output_dir / "report.md"
+        report_path.write_text(report, encoding="utf-8")
+        return report_path
+
+
+def _score_row(label: str, baseline: int, skilled: int, *, bold: bool = False) -> str:
+    """Format one scoring table row."""
+
+    delta = skilled - baseline
+    name = label if not bold else label
+    return f"| {name} | {baseline}/5 | {skilled}/5 | {delta:+d} |"
+
+
+def _rationale_block(result: ScoringResult) -> str:
+    """Format dimension rationales as bullet list."""
+
+    return "\n".join(
+        [
+            f"- **Coverage ({result.coverage.score}/5):** {result.coverage.rationale}",
+            f"- **Specificity ({result.specificity.score}/5):** {result.specificity.rationale}",
+            f"- **Correctness ({result.correctness.score}/5):** {result.correctness.rationale}",
+            f"- **Completeness ({result.completeness.score}/5):** {result.completeness.rationale}",
+        ]
+    )
+
+
+def _key_observation(comparison: BenchmarkComparison) -> str:
+    """Summarize the largest scoring delta dimension."""
+
+    deltas = {
+        "coverage": comparison.skilled_score.coverage.score
+        - comparison.baseline_score.coverage.score,
+        "specificity": comparison.skilled_score.specificity.score
+        - comparison.baseline_score.specificity.score,
+        "correctness": comparison.skilled_score.correctness.score
+        - comparison.baseline_score.correctness.score,
+        "completeness": comparison.skilled_score.completeness.score
+        - comparison.baseline_score.completeness.score,
+    }
+    best_dim = max(deltas, key=deltas.get)
+    return (
+        f"Largest gain in **{best_dim}** ({deltas[best_dim]:+d}). "
+        f"Overall verdict: {comparison.verdict}."
+    )

--- a/tools/skill-benchmark/src/skill_benchmark/runner.py
+++ b/tools/skill-benchmark/src/skill_benchmark/runner.py
@@ -1,0 +1,105 @@
+"""End-to-end benchmark orchestration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .agents.generator import GeneratorAgent
+from .agents.scorer import ScorerAgent
+from .config import BenchmarkConfig
+from .loader import SkillLoader, TaskLoader
+from .models import BenchmarkComparison
+from .paths import find_repo_root
+from .provider import LLMProvider
+from .report import ReportGenerator
+
+
+class BenchmarkRunner:
+    """Run a full baseline vs with-skill benchmark pipeline."""
+
+    def __init__(
+        self,
+        config: BenchmarkConfig,
+        *,
+        repo_root: Path | None = None,
+        generator: GeneratorAgent | None = None,
+        scorer: ScorerAgent | None = None,
+    ) -> None:
+        """Create a runner with optional injected agents for tests.
+
+        Args:
+            config (BenchmarkConfig): Benchmark configuration.
+            repo_root (Path | None): Repository root override.
+            generator (GeneratorAgent | None): Optional generator for tests.
+            scorer (ScorerAgent | None): Optional scorer for tests.
+        """
+
+        self._config = config
+        self._repo_root = repo_root or find_repo_root()
+        self._task_loader = TaskLoader(self._repo_root)
+        self._skill_loader = SkillLoader(self._repo_root)
+        self._generator = generator or GeneratorAgent(LLMProvider(config))
+        self._scorer = scorer or ScorerAgent(config)
+        self._reporter = ReportGenerator()
+
+    @property
+    def repo_root(self) -> Path:
+        """Return the resolved repository root."""
+
+        return self._repo_root
+
+    def resolve_tmp_dir(self) -> Path:
+        """Return absolute tmp output directory."""
+
+        return self._resolve_path(self._config.tmp_dir)
+
+    def resolve_docs_dir(self) -> Path:
+        """Return absolute docs output directory."""
+
+        return self._resolve_path(self._config.docs_dir)
+
+    async def run(self, skill_name: str, task_name: str) -> BenchmarkComparison:
+        """Execute one benchmark and write artefacts.
+
+        Args:
+            skill_name (str): Skill directory name under `skills/`.
+            task_name (str): Task file stem under docs/skills/benchmark/tasks/.
+
+        Returns:
+            BenchmarkComparison: Structured comparison with scores and verdict.
+        """
+
+        task = self._task_loader.load(task_name)
+        skill = self._skill_loader.load(skill_name)
+
+        baseline = await self._generator.generate(task, skill=None)
+        skilled = await self._generator.generate(task, skill=skill)
+
+        baseline_score = await self._scorer.score(task, baseline.output)
+        skilled_score = await self._scorer.score(task, skilled.output)
+
+        comparison = BenchmarkComparison(
+            task=task,
+            skill_name=skill_name,
+            baseline_output=baseline.output,
+            skilled_output=skilled.output,
+            baseline_score=baseline_score,
+            skilled_score=skilled_score,
+        )
+
+        tmp_dir = self.resolve_tmp_dir() / skill_name
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+        (tmp_dir / "output-baseline.md").write_text(baseline.output, encoding="utf-8")
+        (tmp_dir / "output-with-skill.md").write_text(skilled.output, encoding="utf-8")
+
+        report = self._reporter.generate(comparison)
+        self._reporter.save(report, skill_name, self.resolve_docs_dir())
+
+        return comparison
+
+    def _resolve_path(self, configured: Path) -> Path:
+        """Resolve repo-relative paths from the repository root."""
+
+        if configured.is_absolute():
+            return configured
+        return (self._repo_root / configured).resolve()

--- a/tools/skill-benchmark/src/skill_benchmark/runner.py
+++ b/tools/skill-benchmark/src/skill_benchmark/runner.py
@@ -1,4 +1,11 @@
-"""End-to-end benchmark orchestration."""
+"""Orchestrate a full baseline vs with-skill benchmark run.
+
+Loads task and skill content, invokes generator and scorer agents, writes
+artefacts under ``tmp/`` and a markdown report under ``docs/skills/benchmark/``,
+and returns a :class:`~skill_benchmark.models.BenchmarkComparison`.
+
+Deliverable: one end-to-end benchmark execution from CLI ``run`` or tests.
+"""
 
 from __future__ import annotations
 

--- a/tools/skill-benchmark/tests/test_cli.py
+++ b/tools/skill-benchmark/tests/test_cli.py
@@ -1,0 +1,33 @@
+from click.testing import CliRunner
+
+from skill_benchmark.cli import cli
+
+
+def test_cli_list_tasks_includes_three_tasks() -> None:
+    """list-tasks should print at least three known benchmark tasks."""
+
+    result = CliRunner().invoke(cli, ["list-tasks"])
+    assert result.exit_code == 0
+    names = result.output.strip().splitlines()
+    assert "issue-creation" in names
+    assert "deployment-checklist" in names
+    assert "adr-authoring" in names
+
+
+def test_cli_dry_run_validates_without_api_key() -> None:
+    """dry-run should succeed without OPENAI_API_KEY."""
+
+    result = CliRunner().invoke(
+        cli,
+        ["run", "issue-workflow", "issue-creation", "--dry-run"],
+    )
+    assert result.exit_code == 0
+    assert "Dry run OK" in result.output
+
+
+def test_cli_unknown_task_fails() -> None:
+    """Unknown task names should produce a non-zero exit code."""
+
+    result = CliRunner().invoke(cli, ["run", "issue-workflow", "missing-task", "--dry-run"])
+    assert result.exit_code != 0
+    assert "Unknown task" in result.output

--- a/tools/skill-benchmark/tests/test_generator.py
+++ b/tools/skill-benchmark/tests/test_generator.py
@@ -1,0 +1,77 @@
+import pytest
+
+from skill_benchmark.agents.generator import GeneratorAgent
+from skill_benchmark.config import BenchmarkConfig
+from skill_benchmark.models import SkillContent, TaskPrompt
+from skill_benchmark.provider import LLMProvider
+
+
+class _RecordingCompletions:
+    def __init__(self) -> None:
+        self.calls: list[list[dict[str, str]]] = []
+
+    async def create(self, *, model, messages, temperature, max_tokens):
+        self.calls.append(messages)
+
+        class _Resp:
+            choices = [type("C", (), {"message": type("M", (), {"content": "generated"})()})()]
+            usage = None
+
+        return _Resp()
+
+
+class _RecordingClient:
+    def __init__(self) -> None:
+        self.chat = type("Chat", (), {"completions": _RecordingCompletions()})()
+
+
+@pytest.mark.asyncio
+async def test_generator_baseline_uses_prompt_only_system(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Baseline generation should not include skill content."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    client = _RecordingClient()
+    provider = LLMProvider(BenchmarkConfig(_env_file=None), client=client)
+    agent = GeneratorAgent(provider)
+
+    task = TaskPrompt(name="t", prompt="Do the task", expected_coverage="")
+    result = await agent.generate(task, skill=None)
+
+    assert result.output == "generated"
+    system = client.chat.completions.calls[0][0]["content"]
+    assert "skill reference" not in system.lower()
+
+
+@pytest.mark.asyncio
+async def test_generator_with_skill_injects_content(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With-skill generation should include skill markdown in the system prompt."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    client = _RecordingClient()
+    provider = LLMProvider(BenchmarkConfig(_env_file=None), client=client)
+    agent = GeneratorAgent(provider)
+
+    task = TaskPrompt(name="t", prompt="Do the task", expected_coverage="")
+    skill = SkillContent(name="issue-workflow", content="SKILL BODY")
+    await agent.generate(task, skill=skill)
+
+    system = client.chat.completions.calls[0][0]["content"]
+    assert "SKILL BODY" in system
+
+
+@pytest.mark.asyncio
+async def test_generator_runs_use_separate_message_lists(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Baseline and with-skill calls must not share message history."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    client = _RecordingClient()
+    provider = LLMProvider(BenchmarkConfig(_env_file=None), client=client)
+    agent = GeneratorAgent(provider)
+    task = TaskPrompt(name="t", prompt="Do the task", expected_coverage="")
+    skill = SkillContent(name="s", content="SKILL")
+
+    await agent.generate(task, skill=None)
+    await agent.generate(task, skill=skill)
+
+    assert len(client.chat.completions.calls) == 2
+    assert client.chat.completions.calls[0] is not client.chat.completions.calls[1]

--- a/tools/skill-benchmark/tests/test_loader.py
+++ b/tools/skill-benchmark/tests/test_loader.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import pytest
+
+from skill_benchmark.loader import SkillLoader, TaskLoader
+
+
+def test_task_loader_lists_known_tasks(repo_root: Path) -> None:
+    """Task loader should discover committed benchmark tasks."""
+
+    names = TaskLoader(repo_root).list_tasks()
+    assert "issue-creation" in names
+    assert "deployment-checklist" in names
+    assert "adr-authoring" in names
+    assert len(names) >= 3
+
+
+def test_task_loader_parses_issue_creation(repo_root: Path) -> None:
+    """Task loader should parse prompt and expected coverage sections."""
+
+    task = TaskLoader(repo_root).load("issue-creation")
+    assert task.name == "issue-creation"
+    assert "hybrid retrieval" in task.prompt
+    assert "Actionable title" in task.expected_coverage
+    assert (
+        task.skill_under_test
+        == "issue-workflow (e.g. issue-acceptance-criteria, issue-check-duplicates)"
+    )
+
+
+def test_skill_loader_lists_and_loads_issue_workflow(repo_root: Path) -> None:
+    """Skill loader should discover and load top-level skills."""
+
+    loader = SkillLoader(repo_root)
+    assert "issue-workflow" in loader.list_skills()
+
+    skill = loader.load("issue-workflow")
+    assert skill.name == "issue-workflow"
+    assert "name: issue-workflow" in skill.content
+
+
+def test_task_loader_missing_task_raises(repo_root: Path) -> None:
+    """Unknown task names should raise FileNotFoundError."""
+
+    with pytest.raises(FileNotFoundError, match="missing-task"):
+        TaskLoader(repo_root).load("missing-task")
+
+
+@pytest.fixture
+def repo_root() -> Path:
+    """Return repository root for integration-style loader tests."""
+
+    from skill_benchmark.paths import find_repo_root
+
+    return find_repo_root()

--- a/tools/skill-benchmark/tests/test_report.py
+++ b/tools/skill-benchmark/tests/test_report.py
@@ -1,0 +1,73 @@
+from skill_benchmark.models import BenchmarkComparison, DimensionScore, ScoringResult, TaskPrompt
+from skill_benchmark.report import ReportGenerator
+
+
+def _sample_comparison(delta: int = 5) -> BenchmarkComparison:
+    """Build a comparison with the requested total score delta."""
+
+    baseline = ScoringResult(
+        coverage=DimensionScore(2, "baseline coverage"),
+        specificity=DimensionScore(2, "baseline specificity"),
+        correctness=DimensionScore(3, "baseline correctness"),
+        completeness=DimensionScore(3, "baseline completeness"),
+    )
+    skilled_total = baseline.total + delta
+    skilled_scores = _scores_for_total(skilled_total)
+    skilled = ScoringResult(
+        coverage=DimensionScore(skilled_scores[0], "skilled coverage"),
+        specificity=DimensionScore(skilled_scores[1], "skilled specificity"),
+        correctness=DimensionScore(skilled_scores[2], "skilled correctness"),
+        completeness=DimensionScore(skilled_scores[3], "skilled completeness"),
+    )
+    return BenchmarkComparison(
+        task=TaskPrompt(name="issue-creation", prompt="Create issue", expected_coverage="criteria"),
+        skill_name="issue-workflow",
+        baseline_output="baseline",
+        skilled_output="skilled",
+        baseline_score=baseline,
+        skilled_score=skilled,
+    )
+
+
+def _scores_for_total(total: int) -> tuple[int, int, int, int]:
+    """Split a total score across four 1-5 dimensions."""
+
+    remaining = max(4, min(20, total))
+    scores = [1, 1, 1, 1]
+    idx = 0
+    while remaining > 4:
+        if scores[idx] < 5:
+            scores[idx] += 1
+            remaining -= 1
+        idx = (idx + 1) % 4
+    return scores[0], scores[1], scores[2], scores[3]
+
+
+def test_report_contains_scoring_table_and_verdict() -> None:
+    """Report markdown should include table, totals, and verdict."""
+
+    report = ReportGenerator().generate(_sample_comparison())
+    assert "## Scoring (1–5 per dimension)" in report
+    assert "| Coverage |" in report
+    assert "**Total**" in report
+    assert "## Verdict" in report
+    assert "Significant Improvement" in report or "significant improvement" in report.lower()
+
+
+def test_verdict_marginal_and_no_improvement() -> None:
+    """Verdict labels should follow delta thresholds."""
+
+    marginal = _sample_comparison(delta=2)
+    assert marginal.verdict == "marginal"
+
+    none = _sample_comparison(delta=0)
+    assert none.verdict == "no improvement"
+
+
+def test_report_save_writes_file(tmp_path) -> None:
+    """ReportGenerator.save should create report.md under skill directory."""
+
+    report = ReportGenerator().generate(_sample_comparison())
+    path = ReportGenerator().save(report, "issue-workflow", tmp_path)
+    assert path == tmp_path / "issue-workflow" / "report.md"
+    assert path.read_text(encoding="utf-8") == report

--- a/tools/skill-benchmark/tests/test_runner.py
+++ b/tools/skill-benchmark/tests/test_runner.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+import pytest
+
+from skill_benchmark.agents.generator import GeneratorAgent
+from skill_benchmark.agents.scorer import ScorerAgent
+from skill_benchmark.config import BenchmarkConfig
+from skill_benchmark.models import (
+    DimensionScore,
+    GenerationResult,
+    ScoringResult,
+    SkillContent,
+    TaskPrompt,
+)
+from skill_benchmark.runner import BenchmarkRunner
+
+
+class _StubGenerator(GeneratorAgent):
+    def __init__(self) -> None:
+        pass
+
+    async def generate(
+        self, task: TaskPrompt, skill: SkillContent | None = None
+    ) -> GenerationResult:
+        label = "with-skill" if skill else "baseline"
+        return GenerationResult(output=f"{label} output for {task.name}", model="stub")
+
+
+class _StubScorer(ScorerAgent):
+    def __init__(self) -> None:
+        pass
+
+    async def score(self, task: TaskPrompt, output: str) -> ScoringResult:
+        if output.startswith("baseline"):
+            return ScoringResult(
+                coverage=DimensionScore(2, "b"),
+                specificity=DimensionScore(2, "b"),
+                correctness=DimensionScore(3, "b"),
+                completeness=DimensionScore(3, "b"),
+            )
+        return ScoringResult(
+            coverage=DimensionScore(5, "s"),
+            specificity=DimensionScore(5, "s"),
+            correctness=DimensionScore(5, "s"),
+            completeness=DimensionScore(4, "s"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_runner_writes_outputs_and_report(
+    repo_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Runner should persist tmp outputs and docs report."""
+
+    monkeypatch.delenv("BENCHMARK_TMP_DIR", raising=False)
+    monkeypatch.delenv("BENCHMARK_DOCS_DIR", raising=False)
+    config = BenchmarkConfig(
+        _env_file=None,
+        tmp_dir=tmp_path / "tmp",
+        docs_dir=tmp_path / "docs",
+    )
+    runner = BenchmarkRunner(
+        config,
+        repo_root=repo_root,
+        generator=_StubGenerator(),
+        scorer=_StubScorer(),
+    )
+
+    comparison = await runner.run("issue-workflow", "issue-creation")
+
+    assert comparison.delta == 9
+    assert comparison.verdict == "significant improvement"
+    assert (tmp_path / "tmp" / "issue-workflow" / "output-baseline.md").is_file()
+    assert (tmp_path / "tmp" / "issue-workflow" / "output-with-skill.md").is_file()
+    report_path = tmp_path / "docs" / "issue-workflow" / "report.md"
+    assert report_path.is_file()
+    assert "issue-workflow" in report_path.read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def repo_root() -> Path:
+    from skill_benchmark.paths import find_repo_root
+
+    return find_repo_root()

--- a/tools/skill-benchmark/tests/test_scorer.py
+++ b/tools/skill-benchmark/tests/test_scorer.py
@@ -1,0 +1,81 @@
+import json
+
+import pytest
+
+from skill_benchmark.agents.scorer import ScorerAgent, _parse_scoring_result
+from skill_benchmark.config import BenchmarkConfig
+from skill_benchmark.models import TaskPrompt
+
+
+class _ScorerCompletions:
+    def __init__(self, payloads: list[str]) -> None:
+        self._payloads = payloads
+        self.calls = 0
+
+    async def create(self, *, model, messages, temperature, max_tokens):
+        content = self._payloads[min(self.calls, len(self._payloads) - 1)]
+        self.calls += 1
+
+        class _Resp:
+            choices = [type("C", (), {"message": type("M", (), {"content": content})()})()]
+            usage = None
+
+        return _Resp()
+
+
+class _ScorerClient:
+    def __init__(self, payloads: list[str]) -> None:
+        self.chat = type("Chat", (), {"completions": _ScorerCompletions(payloads)})()
+
+
+def test_parse_scoring_result_accepts_fenced_json() -> None:
+    """Parser should read JSON wrapped in markdown fences."""
+
+    raw = """```json
+{
+  "coverage": {"score": 3, "rationale": "ok"},
+  "specificity": {"score": 4, "rationale": "good"},
+  "correctness": {"score": 5, "rationale": "fine"},
+  "completeness": {"score": 2, "rationale": "partial"}
+}
+```"""
+    result = _parse_scoring_result(raw)
+    assert result.total == 14
+    assert result.coverage.score == 3
+
+
+def test_parse_scoring_result_rejects_invalid_score() -> None:
+    """Invalid dimension scores should raise ValueError."""
+
+    raw = json.dumps(
+        {
+            "coverage": {"score": 6, "rationale": "too high"},
+            "specificity": {"score": 3, "rationale": "ok"},
+            "correctness": {"score": 3, "rationale": "ok"},
+            "completeness": {"score": 3, "rationale": "ok"},
+        }
+    )
+    with pytest.raises(ValueError, match="Invalid score"):
+        _parse_scoring_result(raw)
+
+
+@pytest.mark.asyncio
+async def test_scorer_retries_on_invalid_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Scorer should retry once when the model returns malformed JSON."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    valid = json.dumps(
+        {
+            "coverage": {"score": 2, "rationale": "a"},
+            "specificity": {"score": 3, "rationale": "b"},
+            "correctness": {"score": 4, "rationale": "c"},
+            "completeness": {"score": 5, "rationale": "d"},
+        }
+    )
+    client = _ScorerClient(["not json", valid])
+    agent = ScorerAgent(BenchmarkConfig(_env_file=None), client=client)
+    task = TaskPrompt(name="t", prompt="prompt", expected_coverage="coverage")
+
+    result = await agent.score(task, "output")
+    assert result.total == 14
+    assert client.chat.completions.calls == 2


### PR DESCRIPTION
## Summary

- Implements task/skill loaders, generator and scorer agents, report generator, and `BenchmarkRunner` (#102, #103, #104).
- Completes CLI: `list-tasks`, `list-skills`, `run` with `--dry-run`, `--base-url`, `--model`, `--scorer-model`.
- Adds 22 unit/integration tests; all pass with ruff clean.
- Ignores `**/.venv/**` in markdownlint so local Python venvs do not break pre-commit.

## Issues

Closes #102
Closes #103
Closes #104

Partially addresses #31 (harness ready; issue-workflow report still needs a live LLM/Ollama run).

## Test plan

- [x] `cd tools/skill-benchmark && uv sync && uv run pytest`
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run skill-benchmark list-tasks` (shows issue-creation, deployment-checklist, adr-authoring)
- [x] `uv run skill-benchmark run issue-workflow issue-creation --dry-run`
- [ ] Optional: run full benchmark with Ollama and commit `docs/skills/benchmark/issue-workflow/report.md`
