### PR TITLE
#79: Azure DevOps skills and workflow docs

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -45,3 +45,4 @@ ignores:
   - "tmp/**"
   - "node_modules/**"
   - ".cursor/**"
+  - "**/.venv/**"

--- a/docs/workflow/README.md
+++ b/docs/workflow/README.md
@@ -5,7 +5,7 @@ This document is the single, platform-independent source of truth for how this r
 Platform-specific guides (command names, exact CI file locations) live beside this doc:
 
 - [GitHub mapping](github.md)
-- [Azure DevOps mapping](azure-devops.md) (when available)
+- [Azure DevOps mapping](azure-devops.md)
 
 ## Scope (non-exhaustive examples)
 

--- a/docs/workflow/azure-devops.md
+++ b/docs/workflow/azure-devops.md
@@ -1,0 +1,155 @@
+# Azure DevOps Workflow Mapping (Platform-Specific)
+
+This guide maps the platform-agnostic workflow in [`docs/workflow/README.md`](README.md) to Azure DevOps conventions and `az` CLI commands.
+
+When in doubt, follow the agnostic workflow first, then apply the matching Azure DevOps tool examples below.
+
+---
+
+## Mapping: platform-agnostic areas to Azure DevOps specifics
+
+| Workflow area | Azure DevOps tool | Skill(s) |
+|---|---|---|
+| Work item discipline | `az boards work-item create/show/update` | [`azure-devops`](../../skills/azure-devops/SKILL.md), [`azure-devops-work-items`](../../skills/azure-devops/azure-devops-work-items/SKILL.md) |
+| Duplicate check | WIQL via `az boards query` | [`azure-devops-work-items`](../../skills/azure-devops/azure-devops-work-items/SKILL.md) |
+| Metadata | Area Path, Iteration, Tags, Assignee | [`azure-devops-work-items`](../../skills/azure-devops/azure-devops-work-items/SKILL.md) |
+| Bulk creation | `az boards work-item create` in a loop | [`azure-devops-work-items`](../../skills/azure-devops/azure-devops-work-items/SKILL.md) |
+| Branching | `git checkout -b feature/NNN-...` + branch policies | [`plan-branch-strategy`](../../skills/plan-branch-strategy/SKILL.md), [`azure-devops-repos`](../../skills/azure-devops/azure-devops-repos/SKILL.md) |
+| Commit linking | `AB#NNN` in commit message | git (auto-links in Azure DevOps) |
+| PR creation | `az repos pr create` | [`azure-devops-repos`](../../skills/azure-devops/azure-devops-repos/SKILL.md) |
+| PR merge | `az repos pr update --status completed` | [`azure-devops-repos`](../../skills/azure-devops/azure-devops-repos/SKILL.md) |
+| Code review | Required reviewers, vote on PR | [`code-review`](../../skills/code-review/SKILL.md), [`azure-devops-repos`](../../skills/azure-devops/azure-devops-repos/SKILL.md) |
+| Quality gate | pre-commit + build validation policy | [`quality-gate`](../../skills/quality-gate/SKILL.md) |
+| CI/CD | `azure-pipelines.yml` (stages, environments) | [`azure-devops-pipelines`](../../skills/azure-devops/azure-devops-pipelines/SKILL.md), [`deployment`](../../skills/deployment/SKILL.md) |
+| Cleanup | `az pipelines runs delete`, branch prune | [`maintenance-cleanup`](../../skills/maintenance/maintenance-cleanup/SKILL.md) |
+| Monitoring | Azure Monitor, Application Insights, pipeline logs | [`operations-monitoring`](../../skills/operations/operations-monitoring/SKILL.md) |
+
+---
+
+## Setup
+
+```bash
+az extension add --name azure-devops
+az devops login --organization https://dev.azure.com/{org}
+az devops configure --defaults organization=https://dev.azure.com/{org} project={project}
+```
+
+---
+
+## Work item lifecycle
+
+### Create a work item
+
+```bash
+az boards work-item create \
+  --title "[FEAT]: verb + object" \
+  --type "Product Backlog Item" \
+  --description "## Goal\n...\n\n## Acceptance Criteria\n- [ ] ..."
+```
+
+### Query for duplicates
+
+```bash
+az boards query --wiql "SELECT [System.Id], [System.Title] FROM WorkItems \
+  WHERE [System.TeamProject] = @project AND [System.Title] CONTAINS 'search terms'"
+```
+
+### Update metadata
+
+```bash
+az boards work-item update --id 12345 \
+  --fields "System.AssignedTo=user@example.com System.IterationPath=Project\\Sprint 1"
+```
+
+---
+
+## Branching and commits
+
+Use the same branch prefixes as the agnostic workflow (`feature/NNN-description`, etc.).
+
+Link commits to work items:
+
+```text
+AB#12345: feat: add hybrid retrieval
+```
+
+---
+
+## Pull requests
+
+### Create PR
+
+```bash
+az repos pr create \
+  --source-branch feature/123-short-description \
+  --target-branch main \
+  --title "feat: ..." \
+  --description "## Summary\n...\n\nRelated work: AB#123"
+```
+
+### Complete PR (merge)
+
+```bash
+az repos pr update --id 42 --status completed --delete-source-branch true
+```
+
+---
+
+## Quality gate and CI/CD
+
+### Local quality gate
+
+Run lint, format, and tests locally before push (same sequence as the agnostic workflow). See [`quality-gate`](../../skills/quality-gate/SKILL.md).
+
+### Pipeline validation on PR
+
+Configure a build validation branch policy so the PR pipeline must pass before merge. Example pipeline skeleton:
+
+```yaml
+pr:
+  branches:
+    include:
+      - main
+
+stages:
+  - stage: Validate
+    jobs:
+      - job: QualityGate
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: self
+          - script: uv run pytest
+            displayName: Run tests
+```
+
+Full patterns: [`azure-devops-pipelines`](../../skills/azure-devops/azure-devops-pipelines/SKILL.md).
+
+### Staged deployment
+
+Use pipeline **environments** with approval checks for production promotion after staging smoke tests pass.
+
+---
+
+## Post-merge cleanup
+
+- Delete merged source branches (`az repos pr update --delete-source-branch true` on complete, or manual git prune)
+- Remove stale pipeline runs: `az pipelines runs delete --id <run-id>`
+
+See [`maintenance-cleanup`](../../skills/maintenance/maintenance-cleanup/SKILL.md) for hygiene patterns.
+
+---
+
+## Human-in-the-loop pause (when using agents)
+
+From [`skills/COOPERATION.md`](../../skills/COOPERATION.md):
+
+After work item refinement and planning, a maintainer may review before coding. Invoke implementation only when the work item has `execution:ai-ok` and an explicit go-ahead.
+
+---
+
+## Related docs
+
+- Agnostic source of truth: [`README.md`](README.md)
+- GitHub mapping: [`github.md`](github.md)
+- Skill orchestrator: [`azure-devops`](../../skills/azure-devops/SKILL.md)

--- a/skills/SKILL_TREE.md
+++ b/skills/SKILL_TREE.md
@@ -497,7 +497,8 @@ Azure Pipelines YAML, build validation on PR, staged deploy with environments.
 | — | ai-agent-development *(domain)* | AI agent implementation | agent-types, agent-context, agent-guardrails, agent-llm-providers, agent-on-premises, agent-frameworks, agent-visual-dev |
 | — | azure-devops *(platform)* | Azure DevOps workflow | azure-devops-work-items, azure-devops-repos, azure-devops-pipelines |
 
-**Total:** 1 meta-skill + 16 lifecycle skills + **V-model overlay** (6 sub-skills) + 1 domain skill (7 sub-skills), 60+ sub-skills elsewhere. Nesting: up to 4–5 levels where needed (e.g. 5.4.1, 5.4.2).
+// Total top-level rows in the table above: *(meta)* (1) + lifecycle 0–15 (16) + *(overlay)* + *(crosscutting)* + *(domain)* + *(platform)*. Parentheses count direct sub-skills where listed; “60+ sub-skills elsewhere” includes nested lifecycle sub-skills (e.g. 5.4.1).
+**Total:** 1 meta-skill + 16 lifecycle skills + **V-model overlay** (6 sub-skills) + 1 crosscutting skill + 1 domain skill (7 sub-skills) + 1 platform skill (3 sub-skills), 60+ sub-skills elsewhere. Nesting: up to 4–5 levels where needed (e.g. 5.4.1, 5.4.2).
 
 ## Implementation Status
 

--- a/skills/SKILL_TREE.md
+++ b/skills/SKILL_TREE.md
@@ -457,6 +457,20 @@ Guides visual/GUI-based agent development with n8n, Flowise, and LangFlow. Cover
 
 ---
 
+### azure-devops
+Orchestrates Azure DevOps work items, repos, and pipelines via `az` CLI. Use when the project uses Azure Boards, Azure Repos, or Azure Pipelines instead of GitHub Issues/Actions.
+
+#### azure-devops-work-items
+Creates, queries, updates, and links Azure Boards work items.
+
+#### azure-devops-repos
+Pull requests, reviewers, merge completion, and branch policies in Azure Repos.
+
+#### azure-devops-pipelines
+Azure Pipelines YAML, build validation on PR, staged deploy with environments.
+
+---
+
 ## Summary: Skill Tree Overview
 
 | # | Skill | arc42 / Lifecycle | Sub-skills |
@@ -481,6 +495,7 @@ Guides visual/GUI-based agent development with n8n, Flowise, and LangFlow. Cover
 | — | v-model *(overlay)* | Traceability pairing (optional) | mapping, requirements-acceptance, architecture-integration, design-verification, implementation-unit, retrofit |
 | — | fair-data-principles *(crosscutting)* | FAIR data quality goals | — |
 | — | ai-agent-development *(domain)* | AI agent implementation | agent-types, agent-context, agent-guardrails, agent-llm-providers, agent-on-premises, agent-frameworks, agent-visual-dev |
+| — | azure-devops *(platform)* | Azure DevOps workflow | azure-devops-work-items, azure-devops-repos, azure-devops-pipelines |
 
 **Total:** 1 meta-skill + 16 lifecycle skills + **V-model overlay** (6 sub-skills) + 1 domain skill (7 sub-skills), 60+ sub-skills elsewhere. Nesting: up to 4–5 levels where needed (e.g. 5.4.1, 5.4.2).
 
@@ -520,3 +535,4 @@ Guides visual/GUI-based agent development with n8n, Flowise, and LangFlow. Cover
 | requirements / design / implementation / validation / test **orchestrator** SKILL.md | ✅ nav + sub-skill links |
 | v-model overlay (#42) | ✅ implemented |
 | ai-agent-development + 7 sub-skills | ✅ implemented (#84) |
+| azure-devops + 3 sub-skills | ✅ implemented (#79) |

--- a/skills/SKILL_TREE.md
+++ b/skills/SKILL_TREE.md
@@ -497,8 +497,8 @@ Azure Pipelines YAML, build validation on PR, staged deploy with environments.
 | — | ai-agent-development *(domain)* | AI agent implementation | agent-types, agent-context, agent-guardrails, agent-llm-providers, agent-on-premises, agent-frameworks, agent-visual-dev |
 | — | azure-devops *(platform)* | Azure DevOps workflow | azure-devops-work-items, azure-devops-repos, azure-devops-pipelines |
 
-// Total top-level rows in the table above: *(meta)* (1) + lifecycle 0–15 (16) + *(overlay)* + *(crosscutting)* + *(domain)* + *(platform)*. Parentheses count direct sub-skills where listed; “60+ sub-skills elsewhere” includes nested lifecycle sub-skills (e.g. 5.4.1).
-**Total:** 1 meta-skill + 16 lifecycle skills + **V-model overlay** (6 sub-skills) + 1 crosscutting skill + 1 domain skill (7 sub-skills) + 1 platform skill (3 sub-skills), 60+ sub-skills elsewhere. Nesting: up to 4–5 levels where needed (e.g. 5.4.1, 5.4.2).
+*Note:* Total counts the table rows above: *(meta)* (1) + lifecycle 0–15 (16) + *(overlay)* + *(crosscutting)* + *(domain)* + *(platform)*. Parentheses count direct sub-skills where listed; “60+ sub-skills elsewhere” includes nested lifecycle sub-skills (e.g. 5.4.1).
+**Total:** 1 meta-skill + 16 lifecycle skills + 1 overlay (**V-model**, 6 sub-skills) + 1 crosscutting skill + 1 domain skill (7 sub-skills) + 1 platform skill (3 sub-skills), 60+ sub-skills elsewhere. Nesting: up to 4–5 levels where needed (e.g. 5.4.1, 5.4.2).
 
 ## Implementation Status
 

--- a/skills/azure-devops/SKILL.md
+++ b/skills/azure-devops/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: azure-devops
+description: Orchestrates Azure DevOps work item, repo, and pipeline workflows using az CLI. Use when working with Azure DevOps, Azure Repos, Azure Boards, Azure Pipelines, or az devops commands.
+---
+
+# Azure DevOps Workflow
+
+Orchestrates the Azure DevOps lifecycle for work items, pull requests, and pipelines. Mirrors the platform-agnostic discipline in [`docs/workflow/README.md`](../../docs/workflow/README.md).
+
+## When to use
+
+- Creating or refining Azure Boards work items (Epic, Feature, PBI, Task, Bug)
+- Opening, reviewing, or completing pull requests in Azure Repos
+- Authoring or validating Azure Pipelines YAML and branch policies
+- Mapping repo workflow conventions to Azure DevOps tooling
+
+## Prerequisites
+
+```bash
+az extension add --name azure-devops
+az devops login --organization https://dev.azure.com/{org}
+az devops configure --defaults organization=https://dev.azure.com/{org} project={project}
+```
+
+## Flow
+
+1. **Work items** — [azure-devops-work-items](azure-devops-work-items/SKILL.md). Create, query, update, link work items.
+2. **Branching** — Same git branch prefixes as the agnostic workflow (`feature/NNN-description`). Link commits with `AB#NNN` in messages.
+3. **Pull requests** — [azure-devops-repos](azure-devops-repos/SKILL.md). Create PR, request reviewers, complete merge.
+4. **Quality gate** — Local checks (lint, test, format) before push; build validation policy on the target branch.
+5. **Pipelines** — [azure-devops-pipelines](azure-devops-pipelines/SKILL.md). CI validation on PR; staged deploy after merge.
+6. **Cleanup** — Prune branches; delete old pipeline runs when repo conventions require it.
+
+## Work item hierarchy
+
+| Type | Role |
+|------|------|
+| Epic | Large initiative spanning multiple features |
+| Feature | Deliverable slice under an epic |
+| Product Backlog Item / User Story | User-facing requirement |
+| Task | Implementation step |
+| Bug | Defect (separate from feature hierarchy) |
+
+## Output templates
+
+Work item body (adapt fields to project process template):
+
+```markdown
+## Goal
+[One sentence: what and why]
+
+## Tasks
+- [ ] ...
+
+## Acceptance Criteria
+- [ ] ... (copy-pastable validation steps)
+
+## Out of Scope
+- ...
+
+## Estimate
+Size: S | M | L
+```
+
+Pull request description:
+
+```markdown
+## Summary
+[What and why]
+
+## Changes
+- ...
+
+Related work: AB#NNN
+```
+
+## Integration
+
+- Platform mapping: [`docs/workflow/azure-devops.md`](../../docs/workflow/azure-devops.md)
+- Agnostic source of truth: [`docs/workflow/README.md`](../../docs/workflow/README.md)
+- GitHub equivalent skills: [`issue-workflow`](../issue-workflow/SKILL.md), [`integration`](../integration/SKILL.md), [`deployment`](../deployment/SKILL.md)

--- a/skills/azure-devops/azure-devops-pipelines/SKILL.md
+++ b/skills/azure-devops/azure-devops-pipelines/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: azure-devops-pipelines
+description: Guides Azure Pipelines YAML structure, build validation on PRs, and staged deployment with environments and approvals. Use when authoring azure-pipelines.yml or configuring CI/CD on Azure DevOps.
+---
+
+# Azure DevOps Pipelines
+
+Defines CI/CD patterns for Azure Pipelines aligned with the agnostic workflow.
+
+## When to use
+
+- Authoring or updating `azure-pipelines.yml`
+- Configuring build validation on pull requests
+- Setting up staged deployment (staging → production) with approvals
+- Cleaning up old pipeline runs
+
+## CI/CD principles
+
+1. **Validation on PR** — lint, test, type check, security scan run when a PR is created or updated.
+2. **Deploy after merge** — staging deploy triggers on merge to `main`; production requires approval.
+3. **Rollback** — previous artefact tag or release can be redeployed if smoke tests fail.
+4. **Evidence** — record pipeline run URL and smoke test outcome before claiming release success.
+
+## Minimal validation pipeline
+
+```yaml
+trigger:
+  branches:
+    include:
+      - main
+
+pr:
+  branches:
+    include:
+      - main
+
+pool:
+  vmImage: ubuntu-latest
+
+stages:
+  - stage: Validate
+    jobs:
+      - job: QualityGate
+        steps:
+          - checkout: self
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: "3.12"
+          - script: |
+              pip install uv
+              uv sync --group dev
+              uv run ruff check .
+              uv run pytest
+            displayName: Lint and test
+```
+
+## Staged deployment with environments
+
+```yaml
+  - stage: DeployStaging
+    dependsOn: Validate
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+    jobs:
+      - deployment: Staging
+        environment: staging
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - script: echo "Deploy to staging"
+                  displayName: Deploy staging
+
+  - stage: DeployProduction
+    dependsOn: DeployStaging
+    jobs:
+      - deployment: Production
+        environment: production   # configure approval check in ADO UI
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - script: echo "Deploy to production"
+                  displayName: Deploy production
+```
+
+## Build validation policy
+
+Link a pipeline to a branch policy so PRs cannot merge until the build succeeds. See [azure-devops-repos](../azure-devops-repos/SKILL.md) for `az repos policy build create`.
+
+## Service connections
+
+Store credentials (container registry, cloud subscription, package feed) as service connections in Project Settings → Service connections. Reference them in YAML:
+
+```yaml
+- task: Docker@2
+  inputs:
+    containerRegistry: my-acr-connection
+    command: buildAndPush
+```
+
+## Pipeline run cleanup
+
+```bash
+az pipelines runs list --pipeline-ids 12 --top 50
+az pipelines runs delete --id 98765
+```
+
+Delete failed or stale runs periodically to reduce noise.
+
+## Integration
+
+- Orchestrator: [azure-devops](../SKILL.md)
+- Release checklist patterns: [deployment-release](../../deployment/deployment-release/SKILL.md) (adapt commands to ADO tasks)
+- Agnostic discipline: [`docs/workflow/README.md`](../../../docs/workflow/README.md)

--- a/skills/azure-devops/azure-devops-repos/SKILL.md
+++ b/skills/azure-devops/azure-devops-repos/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: azure-devops-repos
+description: Creates, reviews, and completes Azure Repos pull requests and branch policies via az repos CLI. Use when opening ADO PRs, setting required reviewers, or configuring build validation policies.
+---
+
+# Azure DevOps Repos
+
+Manages Azure Repos pull requests and branch policies.
+
+## When to use
+
+- Creating a pull request after local quality gates pass
+- Requesting reviewers and recording review votes
+- Completing (merging) a PR with squash or merge commit
+- Configuring branch policies on `main` or release branches
+
+## Branch naming
+
+Use the same prefixes as the agnostic workflow:
+
+- `feature/NNN-short-description`
+- `hotfix/NNN-short-description`
+- `chore/NNN-short-description`
+
+Link every commit to a work item with `AB#NNN` in the message.
+
+## Create a pull request
+
+```bash
+az repos pr create \
+  --source-branch feature/123-hybrid-retrieval \
+  --target-branch main \
+  --title "feat: add hybrid retrieval" \
+  --description "## Summary\n...\n\nRelated work: AB#123"
+```
+
+## List and view PRs
+
+```bash
+az repos pr list --status active
+az repos pr show --id 42
+```
+
+## Request reviewers
+
+```bash
+az repos pr reviewer add --id 42 --reviewers user@example.com
+```
+
+Reviewers vote: `approve`, `approve-with-suggestions`, `wait-for-author`, or `reject`.
+
+## Complete (merge) a PR
+
+```bash
+az repos pr update --id 42 --status completed --delete-source-branch true
+```
+
+Use `--squash true` when the team prefers a single commit on the target branch.
+
+## Branch policies
+
+Typical policies on `main`:
+
+| Policy | Purpose |
+|--------|---------|
+| Required reviewers | At least one approval before merge |
+| Build validation | Azure Pipeline must succeed on the PR |
+| Comment resolution | All PR comments resolved |
+
+```bash
+az repos policy list --branch main
+az repos policy build create \
+  --branch main \
+  --build-definition-id 12 \
+  --display-name "CI validation" \
+  --enabled true \
+  --blocking true
+```
+
+## PR description template
+
+```markdown
+## Summary
+[What and why]
+
+## Changes
+- ...
+
+## Validation evidence
+- [ ] Lint passed locally
+- [ ] Tests passed locally
+- [ ] Pipeline green on PR
+
+Related work: AB#NNN
+```
+
+## Integration
+
+- Orchestrator: [azure-devops](../SKILL.md)
+- Agnostic discipline: [`docs/workflow/README.md`](../../../docs/workflow/README.md)

--- a/skills/azure-devops/azure-devops-work-items/SKILL.md
+++ b/skills/azure-devops/azure-devops-work-items/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: azure-devops-work-items
+description: Creates, queries, updates, and links Azure Boards work items via az boards CLI. Use when filing ADO work items, running WIQL queries, or setting area path, iteration, tags, and assignee.
+---
+
+# Azure DevOps Work Items
+
+Manages Azure Boards work items with the same discipline as the agnostic issue workflow.
+
+## When to use
+
+- Creating a new Epic, Feature, PBI/User Story, Task, or Bug
+- Searching for duplicates before starting work
+- Updating metadata (area path, iteration, tags, assignee)
+- Linking parent/child or related work items
+
+## Create a work item
+
+```bash
+az boards work-item create \
+  --title "[FEAT]: Add hybrid retrieval" \
+  --type "Product Backlog Item" \
+  --description "## Goal\n...\n\n## Acceptance Criteria\n- [ ] ..." \
+  --fields "System.AssignedTo=user@example.com"
+```
+
+Common types vary by process template: `Epic`, `Feature`, `Product Backlog Item`, `User Story`, `Task`, `Bug`.
+
+## View and update
+
+```bash
+az boards work-item show --id 12345
+az boards work-item update --id 12345 --title "Updated title"
+az boards work-item update --id 12345 --fields "System.Tags=ready-for-agent"
+```
+
+## Duplicate check (WIQL)
+
+```bash
+az boards query --wiql "SELECT [System.Id], [System.Title] FROM WorkItems \
+  WHERE [System.TeamProject] = @project \
+  AND [System.Title] CONTAINS 'hybrid retrieval' \
+  AND [System.State] <> 'Removed' \
+  ORDER BY [System.ChangedDate] DESC"
+```
+
+## Link work items
+
+```bash
+az boards work-item relation add --id 12345 \
+  --relation-type parent \
+  --target-id 12340
+```
+
+Relation types include `parent`, `child`, `related`, and `duplicate`.
+
+## Commit linking
+
+Include `AB#12345` in commit messages so Azure DevOps links commits to the work item automatically.
+
+## Required sections
+
+Every work item should include:
+
+- **Goal** — one sentence outcome and why
+- **Tasks** — numbered actionable steps
+- **Acceptance Criteria** — testable checkboxes with validation steps
+- **Out of Scope** — explicit exclusions
+- **Estimate** — T-shirt size or hours
+
+## Integration
+
+- Orchestrator: [azure-devops](../SKILL.md)
+- Agnostic discipline: [`docs/workflow/README.md`](../../../docs/workflow/README.md)


### PR DESCRIPTION
## Summary

- Adds `azure-devops` orchestrator skill with sub-skills for work items, repos, and pipelines (#79).
- Creates `docs/workflow/azure-devops.md` mapping the platform-agnostic workflow to `az` CLI and Azure Pipelines patterns.
- Updates `SKILL_TREE.md` and removes "(when available)" from the Azure DevOps link in `docs/workflow/README.md`.

## Issues

Closes #79

## Test plan

- [x] `bash scripts/validate-skill-frontmatter.sh skills/azure-devops/`
- [x] `npx skills-ref@0.1.5 validate` on all four new skill directories
- [x] Pre-commit markdownlint + skill frontmatter hooks pass
- [ ] Review skill content for ADO accuracy against your org's process template
