### PR TITLE
#118: Fix CI base image HF 429 and cron schedule

### DIFF
--- a/.github/workflows/build-ci-base-images.yml
+++ b/.github/workflows/build-ci-base-images.yml
@@ -2,12 +2,13 @@
 # Images: ci-base-3.12, ci-hf-base-3.12, ci-whisper-3.12
 # All assets in ci-base-images/ directory.
 # Prerequisite: ghcr.io access (GITHUB_TOKEN has packages: write).
+# Prerequisite: HF_TOKEN secret for ci-hf-base model download (read token).
 name: Build CI Base Images
 
 on:
   schedule:
-    # First Saturday night of each month at 00:00 UTC
-    - cron: "0 0 1-7 * 6"
+    # Every Saturday 00:00 UTC; should-run gate keeps first Saturday of month only.
+    - cron: "0 0 * * 6"
   push:
     branches: [main]
     paths:
@@ -24,7 +25,25 @@ permissions:
   packages: write
 
 jobs:
+  should-run:
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
+    steps:
+      - name: Check schedule gate
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" != "schedule" ]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          elif [ "$(date -u +%d)" -le 7 ]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build-and-push:
+    needs: should-run
+    if: needs.should-run.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -61,6 +80,8 @@ jobs:
           tags: ghcr.io/pkuppens/pkuppens/ci-hf-base-3.12:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          secrets: |
+            hf_token=${{ secrets.HF_TOKEN }}
 
       - name: Build and push ci-whisper-3.12
         uses: docker/build-push-action@v6

--- a/ci-base-images/Dockerfile.ci-hf-base-3.12
+++ b/ci-base-images/Dockerfile.ci-hf-base-3.12
@@ -1,6 +1,7 @@
 # ci-hf-base-3.12: ci-base-3.12 + HuggingFace env + embedding models.
 # For RAG, embedding tests (e.g. on_prem_rag).
 # Sibling to ci-whisper-3.12; tokenization for text differs from STT.
+# syntax=docker/dockerfile:1
 FROM ghcr.io/pkuppens/pkuppens/ci-base-3.12:latest
 
 LABEL org.opencontainers.image.documentation="https://github.com/pkuppens/pkuppens/blob/main/ci-base-images/README.md"
@@ -13,15 +14,22 @@ ENV TRANSFORMERS_CACHE=/opt/hf_cache/hub
 ENV SENTENCE_TRANSFORMERS_HOME=/opt/hf_cache/sentence_transformers
 ENV HF_HUB_DISABLE_PROGRESS_BARS=1
 
-# Install HuggingFace deps (sentence-transformers pulls torch, transformers)
-RUN uv pip install --system \
-    sentence-transformers>=2.2.0 \
-    transformers>=4.37.0 \
-    torch>=2.2.0
+# Pinned deps in a separate layer so script-only changes do not bust pip cache.
+COPY ci-base-images/requirements-hf.txt /tmp/requirements-hf.txt
+RUN uv pip install --system -r /tmp/requirements-hf.txt && rm /tmp/requirements-hf.txt
 
 # Pre-download CI models (matching setup_embedding_models.py --ci)
 COPY ci-base-images/download_hf_ci_models.py /tmp/download_hf_ci_models.py
-RUN python /tmp/download_hf_ci_models.py && rm /tmp/download_hf_ci_models.py
+RUN --mount=type=cache,target=/root/.cache/huggingface \
+    --mount=type=secret,id=hf_token \
+    sh -c '\
+      export HF_TOKEN=$(cat /run/secrets/hf_token); \
+      for i in 1 2 3; do \
+        python /tmp/download_hf_ci_models.py && break || \
+        if [ "$i" = "3" ]; then exit 1; fi; \
+        sleep $((i * 60)); \
+      done' \
+    && rm /tmp/download_hf_ci_models.py
 
 # Free disk: compiler stack was only needed for pip builds above; HF caches need the space.
 RUN apt-get update \

--- a/ci-base-images/README.md
+++ b/ci-base-images/README.md
@@ -26,6 +26,7 @@ ci-hf-base and ci-whisper are **siblings** (both FROM ci-base-3.12). Text tokeni
 - **Image size**: ci-hf-base ~2GB; ci-whisper ~1.5GB
 - **Rebuild cadence**: Monthly (schedule) or manual (workflow_dispatch)
 - **ghcr.io access**: Requires `packages: write` for the build workflow. Validate with a manual run of Build CI Base Images.
+- **HF_TOKEN secret**: Add a Hugging Face read token as repo secret `HF_TOKEN` before building ci-hf-base (avoids anonymous rate limits).
 - **github.io**: Considered separately for deployments; document if/when used.
 
 ## Version Matrix

--- a/ci-base-images/download_hf_ci_models.py
+++ b/ci-base-images/download_hf_ci_models.py
@@ -5,24 +5,38 @@ Matches on_prem_rag setup_embedding_models.py --ci models:
 - sentence-transformers/all-MiniLM-L6-v2
 - BAAI/bge-small-en-v1.5
 
-Run with: python download_hf_ci_models.py
-Environment: HF_HOME, TRANSFORMERS_CACHE, SENTENCE_TRANSFORMERS_HOME must be set.
+Uses snapshot_download with pinned revisions and HF_TOKEN when set.
 """
 
 from __future__ import annotations
 
 import os
+import sys
+import time
 
-# Minimal imports to avoid pulling full llama-index etc.
 try:
+    from huggingface_hub import snapshot_download
     from sentence_transformers import SentenceTransformer
     from transformers import AutoModel, AutoTokenizer
-except ImportError as e:
-    raise SystemExit(f"Required packages not installed: {e}") from e
+except ImportError as exc:
+    raise SystemExit(f"Required packages not installed: {exc}") from exc
+
+# Pinned revisions (HF commit SHAs) for reproducible CI builds.
+CI_MODELS: list[tuple[str, str]] = [
+    ("sentence-transformers/all-MiniLM-L6-v2", "1110a243fdf4706b3f48f1d95db1a4f5529b4d41"),
+    ("BAAI/bge-small-en-v1.5", "5c38ec7c405ec4b44b94cc5a9bb96e735b38267a"),
+]
+
+MAX_ATTEMPTS = 3
+RETRY_SLEEP_SECONDS = 60
 
 
-def main() -> None:
-    """Download CI embedding models."""
+def _hf_token() -> str | None:
+    token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    return token if token else None
+
+
+def _setup_cache_dirs() -> str:
     hf_home = os.environ.get("HF_HOME", "/opt/hf_cache")
     transformers_cache = os.environ.get("TRANSFORMERS_CACHE", f"{hf_home}/hub")
     st_home = os.environ.get("SENTENCE_TRANSFORMERS_HOME", f"{hf_home}/sentence_transformers")
@@ -34,17 +48,62 @@ def main() -> None:
     os.environ["HF_HOME"] = hf_home
     os.environ["TRANSFORMERS_CACHE"] = transformers_cache
     os.environ["SENTENCE_TRANSFORMERS_HOME"] = st_home
+    return hf_home
 
-    # sentence-transformers
-    print("[Download] sentence-transformers/all-MiniLM-L6-v2")
-    SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2", device="cpu")
 
-    # transformers (bge-small)
-    print("[Download] BAAI/bge-small-en-v1.5")
-    AutoModel.from_pretrained("BAAI/bge-small-en-v1.5")
-    AutoTokenizer.from_pretrained("BAAI/bge-small-en-v1.5")
+def _download_models(cache_dir: str) -> list[str]:
+    token = _hf_token()
+    local_paths: list[str] = []
 
-    print("[OK] CI models downloaded")
+    for repo_id, revision in CI_MODELS:
+        print(f"[Download] {repo_id} @ {revision[:12]}")
+        local_path = snapshot_download(
+            repo_id=repo_id,
+            revision=revision,
+            cache_dir=cache_dir,
+            token=token,
+        )
+        local_paths.append(local_path)
+        print(f"[OK] {repo_id} -> {local_path}")
+
+    return local_paths
+
+
+def _smoke_test(local_paths: list[str]) -> None:
+    minilm_path, bge_path = local_paths
+
+    print("[Smoke] SentenceTransformer load")
+    model = SentenceTransformer(minilm_path, device="cpu")
+    model.encode(["CI model cache smoke test"])
+
+    print("[Smoke] BGE AutoModel + AutoTokenizer load")
+    AutoModel.from_pretrained(bge_path)
+    AutoTokenizer.from_pretrained(bge_path)
+
+
+def main() -> None:
+    """Download CI embedding models with retries."""
+    cache_dir = _setup_cache_dirs()
+    token = _hf_token()
+    print(f"[Config] HF_TOKEN present: {bool(token)}")
+
+    last_error: Exception | None = None
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        try:
+            local_paths = _download_models(cache_dir)
+            _smoke_test(local_paths)
+            print("[OK] CI models downloaded and validated")
+            return
+        except Exception as exc:  # noqa: BLE001 — retry any hub/network failure
+            last_error = exc
+            if attempt >= MAX_ATTEMPTS:
+                break
+            sleep_for = RETRY_SLEEP_SECONDS * attempt
+            print(f"[Retry] attempt {attempt}/{MAX_ATTEMPTS} failed: {exc}", file=sys.stderr)
+            print(f"[Retry] sleeping {sleep_for}s before next attempt")
+            time.sleep(sleep_for)
+
+    raise SystemExit(f"Model download failed after {MAX_ATTEMPTS} attempts: {last_error}") from last_error
 
 
 if __name__ == "__main__":

--- a/ci-base-images/requirements-hf.txt
+++ b/ci-base-images/requirements-hf.txt
@@ -1,0 +1,5 @@
+# Pinned HF stack for ci-hf-base-3.12 (stable Docker layer cache).
+sentence-transformers==5.5.1
+transformers==5.10.2
+torch==2.12.0
+huggingface-hub==1.17.0


### PR DESCRIPTION
## Summary
- Fix cron OR-logic bug: schedule now runs first Saturday of month only (gate job on `0 0 * * 6`).
- Wire `HF_TOKEN` into ci-hf-base Docker build via BuildKit secret.
- Pin HF Python deps (`requirements-hf.txt`) and model revisions; use `snapshot_download` with retries.
- Add BuildKit cache mount for Hugging Face hub cache during download.

## Test plan
- [x] workflow_dispatch on feature branch: https://github.com/pkuppens/pkuppens/actions/runs/26996927037 (green)

Closes #118

Made with [Cursor](https://cursor.com)